### PR TITLE
fix(labeler): add explicit permissions to labeler github action

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -3,13 +3,16 @@ name: labeler
 on:
   - pull_request_target
 
+permissions: write-all
+
 jobs:
   label:
-    permissions:
-      contents: read
-      pull-requests: write
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/labeler@v5
         with:
           repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          sync-labels: false
+          configuration-path: .github/labeler.yml
+          dot: true


### PR DESCRIPTION
solved this by manually creating the labels, so closing as not needed.
Labels created:
```
ci
dashboard
consent
pay
admin-panel
map
voucher
core
api-keys
notifications
```