### PR TITLE
feat: earn section skip rewards

### DIFF
--- a/apps/consent/app/graphql/generated.ts
+++ b/apps/consent/app/graphql/generated.ts
@@ -1619,6 +1619,7 @@ export type Quiz = {
 
 export type QuizClaimInput = {
   readonly id: Scalars['ID']['input'];
+  readonly skipRewards?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type QuizClaimPayload = {
@@ -2246,8 +2247,8 @@ export function useCountryCodesLazyQuery(baseOptions?: Apollo.LazyQueryHookOptio
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<CountryCodesQuery, CountryCodesQueryVariables>(CountryCodesDocument, options);
         }
-export function useCountryCodesSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<CountryCodesQuery, CountryCodesQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useCountryCodesSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<CountryCodesQuery, CountryCodesQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<CountryCodesQuery, CountryCodesQueryVariables>(CountryCodesDocument, options);
         }
 export type CountryCodesQueryHookResult = ReturnType<typeof useCountryCodesQuery>;
@@ -2285,8 +2286,8 @@ export function useGetUserIdLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<GetUserIdQuery, GetUserIdQueryVariables>(GetUserIdDocument, options);
         }
-export function useGetUserIdSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GetUserIdQuery, GetUserIdQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useGetUserIdSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetUserIdQuery, GetUserIdQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<GetUserIdQuery, GetUserIdQueryVariables>(GetUserIdDocument, options);
         }
 export type GetUserIdQueryHookResult = ReturnType<typeof useGetUserIdQuery>;

--- a/apps/dashboard/services/graphql/generated.ts
+++ b/apps/dashboard/services/graphql/generated.ts
@@ -1744,6 +1744,7 @@ export type Quiz = {
 
 export type QuizClaimInput = {
   readonly id: Scalars['ID']['input'];
+  readonly skipRewards?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type QuizClaimPayload = {
@@ -3025,8 +3026,8 @@ export function useApiKeysLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<Ap
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<ApiKeysQuery, ApiKeysQueryVariables>(ApiKeysDocument, options);
         }
-export function useApiKeysSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<ApiKeysQuery, ApiKeysQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useApiKeysSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<ApiKeysQuery, ApiKeysQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<ApiKeysQuery, ApiKeysQueryVariables>(ApiKeysDocument, options);
         }
 export type ApiKeysQueryHookResult = ReturnType<typeof useApiKeysQuery>;
@@ -3069,8 +3070,8 @@ export function useCallbackEndpointsLazyQuery(baseOptions?: Apollo.LazyQueryHook
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<CallbackEndpointsQuery, CallbackEndpointsQueryVariables>(CallbackEndpointsDocument, options);
         }
-export function useCallbackEndpointsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<CallbackEndpointsQuery, CallbackEndpointsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useCallbackEndpointsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<CallbackEndpointsQuery, CallbackEndpointsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<CallbackEndpointsQuery, CallbackEndpointsQueryVariables>(CallbackEndpointsDocument, options);
         }
 export type CallbackEndpointsQueryHookResult = ReturnType<typeof useCallbackEndpointsQuery>;
@@ -3170,8 +3171,8 @@ export function useGetPaginatedTransactionsLazyQuery(baseOptions?: Apollo.LazyQu
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<GetPaginatedTransactionsQuery, GetPaginatedTransactionsQueryVariables>(GetPaginatedTransactionsDocument, options);
         }
-export function useGetPaginatedTransactionsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GetPaginatedTransactionsQuery, GetPaginatedTransactionsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useGetPaginatedTransactionsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetPaginatedTransactionsQuery, GetPaginatedTransactionsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<GetPaginatedTransactionsQuery, GetPaginatedTransactionsQueryVariables>(GetPaginatedTransactionsDocument, options);
         }
 export type GetPaginatedTransactionsQueryHookResult = ReturnType<typeof useGetPaginatedTransactionsQuery>;
@@ -3269,8 +3270,8 @@ export function useGetFirstTransactionsLazyQuery(baseOptions?: Apollo.LazyQueryH
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<GetFirstTransactionsQuery, GetFirstTransactionsQueryVariables>(GetFirstTransactionsDocument, options);
         }
-export function useGetFirstTransactionsSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GetFirstTransactionsQuery, GetFirstTransactionsQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useGetFirstTransactionsSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetFirstTransactionsQuery, GetFirstTransactionsQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<GetFirstTransactionsQuery, GetFirstTransactionsQueryVariables>(GetFirstTransactionsDocument, options);
         }
 export type GetFirstTransactionsQueryHookResult = ReturnType<typeof useGetFirstTransactionsQuery>;
@@ -3310,8 +3311,8 @@ export function useGetDefaultWalletByUsernameLazyQuery(baseOptions?: Apollo.Lazy
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<GetDefaultWalletByUsernameQuery, GetDefaultWalletByUsernameQueryVariables>(GetDefaultWalletByUsernameDocument, options);
         }
-export function useGetDefaultWalletByUsernameSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<GetDefaultWalletByUsernameQuery, GetDefaultWalletByUsernameQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useGetDefaultWalletByUsernameSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<GetDefaultWalletByUsernameQuery, GetDefaultWalletByUsernameQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<GetDefaultWalletByUsernameQuery, GetDefaultWalletByUsernameQueryVariables>(GetDefaultWalletByUsernameDocument, options);
         }
 export type GetDefaultWalletByUsernameQueryHookResult = ReturnType<typeof useGetDefaultWalletByUsernameQuery>;
@@ -3372,8 +3373,8 @@ export function useMeLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<MeQuery
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<MeQuery, MeQueryVariables>(MeDocument, options);
         }
-export function useMeSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<MeQuery, MeQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useMeSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<MeQuery, MeQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<MeQuery, MeQueryVariables>(MeDocument, options);
         }
 export type MeQueryHookResult = ReturnType<typeof useMeQuery>;
@@ -3422,8 +3423,8 @@ export function useRealtimePriceLazyQuery(baseOptions?: Apollo.LazyQueryHookOpti
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<RealtimePriceQuery, RealtimePriceQueryVariables>(RealtimePriceDocument, options);
         }
-export function useRealtimePriceSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<RealtimePriceQuery, RealtimePriceQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useRealtimePriceSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<RealtimePriceQuery, RealtimePriceQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<RealtimePriceQuery, RealtimePriceQueryVariables>(RealtimePriceDocument, options);
         }
 export type RealtimePriceQueryHookResult = ReturnType<typeof useRealtimePriceQuery>;
@@ -3498,21 +3499,21 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 ) => TResult | Promise<TResult>;
 
 /** Mapping of union types */
-export type ResolversUnionTypes<RefType extends Record<string, unknown>> = {
+export type ResolversUnionTypes<_RefType extends Record<string, unknown>> = {
   InitiationVia: ( InitiationViaIntraLedger ) | ( InitiationViaLn ) | ( InitiationViaOnChain );
   NotificationAction: ( OpenDeepLinkAction ) | ( OpenExternalLinkAction );
   SettlementVia: ( SettlementViaIntraLedger ) | ( SettlementViaLn ) | ( SettlementViaOnChain );
-  UserUpdate: ( IntraLedgerUpdate ) | ( LnUpdate ) | ( OnChainUpdate ) | ( Price ) | ( RealtimePrice );
+  UserUpdate: ( Omit<IntraLedgerUpdate, 'transaction'> & { transaction: _RefType['Transaction'] } ) | ( Omit<LnUpdate, 'transaction'> & { transaction: _RefType['Transaction'] } ) | ( Omit<OnChainUpdate, 'transaction'> & { transaction: _RefType['Transaction'] } ) | ( Price ) | ( RealtimePrice );
 };
 
 /** Mapping of interface types */
-export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = {
-  Account: ( ConsumerAccount );
+export type ResolversInterfaceTypes<_RefType extends Record<string, unknown>> = {
+  Account: ( Omit<ConsumerAccount, 'callbackEndpoints' | 'invoices' | 'limits' | 'pendingIncomingTransactions' | 'transactions' | 'walletById' | 'wallets'> & { callbackEndpoints: ReadonlyArray<_RefType['CallbackEndpoint']>, invoices?: Maybe<_RefType['InvoiceConnection']>, limits: _RefType['AccountLimits'], pendingIncomingTransactions: ReadonlyArray<_RefType['Transaction']>, transactions?: Maybe<_RefType['TransactionConnection']>, walletById: _RefType['Wallet'], wallets: ReadonlyArray<_RefType['Wallet']> } );
   AccountLimit: ( OneDayAccountLimit );
   Error: ( GraphQlApplicationError );
   Invoice: ( LnInvoice ) | ( LnNoAmountInvoice );
   PriceInterface: ( PriceOfOneSatInMinorUnit ) | ( PriceOfOneSettlementMinorUnitInDisplayMinorUnit ) | ( PriceOfOneUsdCentInMinorUnit );
-  Wallet: ( BtcWallet ) | ( UsdWallet );
+  Wallet: ( Omit<BtcWallet, 'invoiceByPaymentHash' | 'invoices' | 'pendingIncomingTransactions' | 'pendingIncomingTransactionsByAddress' | 'transactionById' | 'transactions' | 'transactionsByAddress' | 'transactionsByPaymentHash' | 'transactionsByPaymentRequest'> & { invoiceByPaymentHash: _RefType['Invoice'], invoices?: Maybe<_RefType['InvoiceConnection']>, pendingIncomingTransactions: ReadonlyArray<_RefType['Transaction']>, pendingIncomingTransactionsByAddress: ReadonlyArray<_RefType['Transaction']>, transactionById: _RefType['Transaction'], transactions?: Maybe<_RefType['TransactionConnection']>, transactionsByAddress?: Maybe<_RefType['TransactionConnection']>, transactionsByPaymentHash: ReadonlyArray<_RefType['Transaction']>, transactionsByPaymentRequest: ReadonlyArray<_RefType['Transaction']> } ) | ( Omit<UsdWallet, 'invoiceByPaymentHash' | 'invoices' | 'pendingIncomingTransactions' | 'pendingIncomingTransactionsByAddress' | 'transactionById' | 'transactions' | 'transactionsByAddress' | 'transactionsByPaymentHash' | 'transactionsByPaymentRequest'> & { invoiceByPaymentHash: _RefType['Invoice'], invoices?: Maybe<_RefType['InvoiceConnection']>, pendingIncomingTransactions: ReadonlyArray<_RefType['Transaction']>, pendingIncomingTransactionsByAddress: ReadonlyArray<_RefType['Transaction']>, transactionById: _RefType['Transaction'], transactions?: Maybe<_RefType['TransactionConnection']>, transactionsByAddress?: Maybe<_RefType['TransactionConnection']>, transactionsByPaymentHash: ReadonlyArray<_RefType['Transaction']>, transactionsByPaymentRequest: ReadonlyArray<_RefType['Transaction']> } );
 };
 
 /** Mapping between all available schema types and the resolvers types */
@@ -3521,7 +3522,7 @@ export type ResolversTypes = {
   String: ResolverTypeWrapper<Scalars['String']['output']>;
   ID: ResolverTypeWrapper<Scalars['ID']['output']>;
   Int: ResolverTypeWrapper<Scalars['Int']['output']>;
-  AccountDeletePayload: ResolverTypeWrapper<AccountDeletePayload>;
+  AccountDeletePayload: ResolverTypeWrapper<Omit<AccountDeletePayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']['output']>;
   AccountDisableNotificationCategoryInput: AccountDisableNotificationCategoryInput;
   AccountDisableNotificationChannelInput: AccountDisableNotificationChannelInput;
@@ -3529,32 +3530,32 @@ export type ResolversTypes = {
   AccountEnableNotificationChannelInput: AccountEnableNotificationChannelInput;
   AccountLevel: AccountLevel;
   AccountLimit: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['AccountLimit']>;
-  AccountLimits: ResolverTypeWrapper<AccountLimits>;
+  AccountLimits: ResolverTypeWrapper<Omit<AccountLimits, 'convert' | 'internalSend' | 'withdrawal'> & { convert: ReadonlyArray<ResolversTypes['AccountLimit']>, internalSend: ReadonlyArray<ResolversTypes['AccountLimit']>, withdrawal: ReadonlyArray<ResolversTypes['AccountLimit']> }>;
   AccountUpdateDefaultWalletIdInput: AccountUpdateDefaultWalletIdInput;
-  AccountUpdateDefaultWalletIdPayload: ResolverTypeWrapper<AccountUpdateDefaultWalletIdPayload>;
+  AccountUpdateDefaultWalletIdPayload: ResolverTypeWrapper<Omit<AccountUpdateDefaultWalletIdPayload, 'account' | 'errors'> & { account?: Maybe<ResolversTypes['ConsumerAccount']>, errors: ReadonlyArray<ResolversTypes['Error']> }>;
   AccountUpdateDisplayCurrencyInput: AccountUpdateDisplayCurrencyInput;
-  AccountUpdateDisplayCurrencyPayload: ResolverTypeWrapper<AccountUpdateDisplayCurrencyPayload>;
-  AccountUpdateNotificationSettingsPayload: ResolverTypeWrapper<AccountUpdateNotificationSettingsPayload>;
+  AccountUpdateDisplayCurrencyPayload: ResolverTypeWrapper<Omit<AccountUpdateDisplayCurrencyPayload, 'account' | 'errors'> & { account?: Maybe<ResolversTypes['ConsumerAccount']>, errors: ReadonlyArray<ResolversTypes['Error']> }>;
+  AccountUpdateNotificationSettingsPayload: ResolverTypeWrapper<Omit<AccountUpdateNotificationSettingsPayload, 'account' | 'errors'> & { account?: Maybe<ResolversTypes['ConsumerAccount']>, errors: ReadonlyArray<ResolversTypes['Error']> }>;
   ApiKey: ResolverTypeWrapper<ApiKey>;
   ApiKeyCreateInput: ApiKeyCreateInput;
   ApiKeyCreatePayload: ResolverTypeWrapper<ApiKeyCreatePayload>;
   ApiKeyRevokeInput: ApiKeyRevokeInput;
   ApiKeyRevokePayload: ResolverTypeWrapper<ApiKeyRevokePayload>;
   AuthToken: ResolverTypeWrapper<Scalars['AuthToken']['output']>;
-  AuthTokenPayload: ResolverTypeWrapper<AuthTokenPayload>;
+  AuthTokenPayload: ResolverTypeWrapper<Omit<AuthTokenPayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
   Authorization: ResolverTypeWrapper<Authorization>;
-  BTCWallet: ResolverTypeWrapper<BtcWallet>;
+  BTCWallet: ResolverTypeWrapper<Omit<BtcWallet, 'invoiceByPaymentHash' | 'invoices' | 'pendingIncomingTransactions' | 'pendingIncomingTransactionsByAddress' | 'transactionById' | 'transactions' | 'transactionsByAddress' | 'transactionsByPaymentHash' | 'transactionsByPaymentRequest'> & { invoiceByPaymentHash: ResolversTypes['Invoice'], invoices?: Maybe<ResolversTypes['InvoiceConnection']>, pendingIncomingTransactions: ReadonlyArray<ResolversTypes['Transaction']>, pendingIncomingTransactionsByAddress: ReadonlyArray<ResolversTypes['Transaction']>, transactionById: ResolversTypes['Transaction'], transactions?: Maybe<ResolversTypes['TransactionConnection']>, transactionsByAddress?: Maybe<ResolversTypes['TransactionConnection']>, transactionsByPaymentHash: ReadonlyArray<ResolversTypes['Transaction']>, transactionsByPaymentRequest: ReadonlyArray<ResolversTypes['Transaction']> }>;
   BuildInformation: ResolverTypeWrapper<BuildInformation>;
   CallbackEndpoint: ResolverTypeWrapper<CallbackEndpoint>;
   CallbackEndpointAddInput: CallbackEndpointAddInput;
-  CallbackEndpointAddPayload: ResolverTypeWrapper<CallbackEndpointAddPayload>;
+  CallbackEndpointAddPayload: ResolverTypeWrapper<Omit<CallbackEndpointAddPayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
   CallbackEndpointDeleteInput: CallbackEndpointDeleteInput;
-  CaptchaCreateChallengePayload: ResolverTypeWrapper<CaptchaCreateChallengePayload>;
+  CaptchaCreateChallengePayload: ResolverTypeWrapper<Omit<CaptchaCreateChallengePayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
   CaptchaCreateChallengeResult: ResolverTypeWrapper<CaptchaCreateChallengeResult>;
   CaptchaRequestAuthCodeInput: CaptchaRequestAuthCodeInput;
   CentAmount: ResolverTypeWrapper<Scalars['CentAmount']['output']>;
-  CentAmountPayload: ResolverTypeWrapper<CentAmountPayload>;
-  ConsumerAccount: ResolverTypeWrapper<ConsumerAccount>;
+  CentAmountPayload: ResolverTypeWrapper<Omit<CentAmountPayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
+  ConsumerAccount: ResolverTypeWrapper<Omit<ConsumerAccount, 'callbackEndpoints' | 'invoices' | 'limits' | 'pendingIncomingTransactions' | 'transactions' | 'walletById' | 'wallets'> & { callbackEndpoints: ReadonlyArray<ResolversTypes['CallbackEndpoint']>, invoices?: Maybe<ResolversTypes['InvoiceConnection']>, limits: ResolversTypes['AccountLimits'], pendingIncomingTransactions: ReadonlyArray<ResolversTypes['Transaction']>, transactions?: Maybe<ResolversTypes['TransactionConnection']>, walletById: ResolversTypes['Wallet'], wallets: ReadonlyArray<ResolversTypes['Wallet']> }>;
   ContactAlias: ResolverTypeWrapper<Scalars['ContactAlias']['output']>;
   Coordinates: ResolverTypeWrapper<Coordinates>;
   Float: ResolverTypeWrapper<Scalars['Float']['output']>;
@@ -3584,11 +3585,11 @@ export type ResolversTypes = {
   InitiationViaLn: ResolverTypeWrapper<InitiationViaLn>;
   InitiationViaOnChain: ResolverTypeWrapper<InitiationViaOnChain>;
   IntraLedgerPaymentSendInput: IntraLedgerPaymentSendInput;
-  IntraLedgerUpdate: ResolverTypeWrapper<IntraLedgerUpdate>;
+  IntraLedgerUpdate: ResolverTypeWrapper<Omit<IntraLedgerUpdate, 'transaction'> & { transaction: ResolversTypes['Transaction'] }>;
   IntraLedgerUsdPaymentSendInput: IntraLedgerUsdPaymentSendInput;
   Invoice: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Invoice']>;
-  InvoiceConnection: ResolverTypeWrapper<InvoiceConnection>;
-  InvoiceEdge: ResolverTypeWrapper<InvoiceEdge>;
+  InvoiceConnection: ResolverTypeWrapper<Omit<InvoiceConnection, 'edges'> & { edges?: Maybe<ReadonlyArray<ResolversTypes['InvoiceEdge']>> }>;
+  InvoiceEdge: ResolverTypeWrapper<Omit<InvoiceEdge, 'node'> & { node: ResolversTypes['Invoice'] }>;
   InvoicePaymentStatus: InvoicePaymentStatus;
   Language: ResolverTypeWrapper<Scalars['Language']['output']>;
   LnAddressPaymentSendInput: LnAddressPaymentSendInput;
@@ -3597,25 +3598,25 @@ export type ResolversTypes = {
   LnInvoiceCreateInput: LnInvoiceCreateInput;
   LnInvoiceCreateOnBehalfOfRecipientInput: LnInvoiceCreateOnBehalfOfRecipientInput;
   LnInvoiceFeeProbeInput: LnInvoiceFeeProbeInput;
-  LnInvoicePayload: ResolverTypeWrapper<LnInvoicePayload>;
+  LnInvoicePayload: ResolverTypeWrapper<Omit<LnInvoicePayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
   LnInvoicePaymentInput: LnInvoicePaymentInput;
   LnInvoicePaymentStatus: ResolverTypeWrapper<LnInvoicePaymentStatus>;
   LnInvoicePaymentStatusByHashInput: LnInvoicePaymentStatusByHashInput;
   LnInvoicePaymentStatusByPaymentRequestInput: LnInvoicePaymentStatusByPaymentRequestInput;
   LnInvoicePaymentStatusInput: LnInvoicePaymentStatusInput;
-  LnInvoicePaymentStatusPayload: ResolverTypeWrapper<LnInvoicePaymentStatusPayload>;
+  LnInvoicePaymentStatusPayload: ResolverTypeWrapper<Omit<LnInvoicePaymentStatusPayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
   LnNoAmountInvoice: ResolverTypeWrapper<LnNoAmountInvoice>;
   LnNoAmountInvoiceCreateInput: LnNoAmountInvoiceCreateInput;
   LnNoAmountInvoiceCreateOnBehalfOfRecipientInput: LnNoAmountInvoiceCreateOnBehalfOfRecipientInput;
   LnNoAmountInvoiceFeeProbeInput: LnNoAmountInvoiceFeeProbeInput;
-  LnNoAmountInvoicePayload: ResolverTypeWrapper<LnNoAmountInvoicePayload>;
+  LnNoAmountInvoicePayload: ResolverTypeWrapper<Omit<LnNoAmountInvoicePayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
   LnNoAmountInvoicePaymentInput: LnNoAmountInvoicePaymentInput;
   LnNoAmountUsdInvoiceFeeProbeInput: LnNoAmountUsdInvoiceFeeProbeInput;
   LnNoAmountUsdInvoicePaymentInput: LnNoAmountUsdInvoicePaymentInput;
   LnPaymentPreImage: ResolverTypeWrapper<Scalars['LnPaymentPreImage']['output']>;
   LnPaymentRequest: ResolverTypeWrapper<Scalars['LnPaymentRequest']['output']>;
   LnPaymentSecret: ResolverTypeWrapper<Scalars['LnPaymentSecret']['output']>;
-  LnUpdate: ResolverTypeWrapper<LnUpdate>;
+  LnUpdate: ResolverTypeWrapper<Omit<LnUpdate, 'transaction'> & { transaction: ResolversTypes['Transaction'] }>;
   LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientInput: LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientInput;
   LnUsdInvoiceCreateInput: LnUsdInvoiceCreateInput;
   LnUsdInvoiceCreateOnBehalfOfRecipientInput: LnUsdInvoiceCreateOnBehalfOfRecipientInput;
@@ -3626,11 +3627,11 @@ export type ResolversTypes = {
   Memo: ResolverTypeWrapper<Scalars['Memo']['output']>;
   Merchant: ResolverTypeWrapper<Merchant>;
   MerchantMapSuggestInput: MerchantMapSuggestInput;
-  MerchantPayload: ResolverTypeWrapper<MerchantPayload>;
+  MerchantPayload: ResolverTypeWrapper<Omit<MerchantPayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
   Minutes: ResolverTypeWrapper<Scalars['Minutes']['output']>;
   MobileVersions: ResolverTypeWrapper<MobileVersions>;
   Mutation: ResolverTypeWrapper<{}>;
-  MyUpdatesPayload: ResolverTypeWrapper<Omit<MyUpdatesPayload, 'update'> & { update?: Maybe<ResolversTypes['UserUpdate']> }>;
+  MyUpdatesPayload: ResolverTypeWrapper<Omit<MyUpdatesPayload, 'errors' | 'me' | 'update'> & { errors: ReadonlyArray<ResolversTypes['Error']>, me?: Maybe<ResolversTypes['User']>, update?: Maybe<ResolversTypes['UserUpdate']> }>;
   Network: Network;
   NotificationAction: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['NotificationAction']>;
   NotificationCategory: ResolverTypeWrapper<Scalars['NotificationCategory']['output']>;
@@ -3640,12 +3641,12 @@ export type ResolversTypes = {
   OnChainAddress: ResolverTypeWrapper<Scalars['OnChainAddress']['output']>;
   OnChainAddressCreateInput: OnChainAddressCreateInput;
   OnChainAddressCurrentInput: OnChainAddressCurrentInput;
-  OnChainAddressPayload: ResolverTypeWrapper<OnChainAddressPayload>;
+  OnChainAddressPayload: ResolverTypeWrapper<Omit<OnChainAddressPayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
   OnChainPaymentSendAllInput: OnChainPaymentSendAllInput;
   OnChainPaymentSendInput: OnChainPaymentSendInput;
   OnChainTxFee: ResolverTypeWrapper<OnChainTxFee>;
   OnChainTxHash: ResolverTypeWrapper<Scalars['OnChainTxHash']['output']>;
-  OnChainUpdate: ResolverTypeWrapper<OnChainUpdate>;
+  OnChainUpdate: ResolverTypeWrapper<Omit<OnChainUpdate, 'transaction'> & { transaction: ResolversTypes['Transaction'] }>;
   OnChainUsdPaymentSendAsBtcDenominatedInput: OnChainUsdPaymentSendAsBtcDenominatedInput;
   OnChainUsdPaymentSendInput: OnChainUsdPaymentSendInput;
   OnChainUsdTxFee: ResolverTypeWrapper<OnChainUsdTxFee>;
@@ -3655,7 +3656,7 @@ export type ResolversTypes = {
   OpenExternalLinkAction: ResolverTypeWrapper<OpenExternalLinkAction>;
   PageInfo: ResolverTypeWrapper<PageInfo>;
   PaymentHash: ResolverTypeWrapper<Scalars['PaymentHash']['output']>;
-  PaymentSendPayload: ResolverTypeWrapper<PaymentSendPayload>;
+  PaymentSendPayload: ResolverTypeWrapper<Omit<PaymentSendPayload, 'errors' | 'transaction'> & { errors: ReadonlyArray<ResolversTypes['Error']>, transaction?: Maybe<ResolversTypes['Transaction']> }>;
   PaymentSendResult: PaymentSendResult;
   PayoutSpeed: PayoutSpeed;
   PayoutSpeeds: ResolverTypeWrapper<PayoutSpeeds>;
@@ -3668,19 +3669,19 @@ export type ResolversTypes = {
   PriceOfOneSatInMinorUnit: ResolverTypeWrapper<PriceOfOneSatInMinorUnit>;
   PriceOfOneSettlementMinorUnitInDisplayMinorUnit: ResolverTypeWrapper<PriceOfOneSettlementMinorUnitInDisplayMinorUnit>;
   PriceOfOneUsdCentInMinorUnit: ResolverTypeWrapper<PriceOfOneUsdCentInMinorUnit>;
-  PricePayload: ResolverTypeWrapper<PricePayload>;
+  PricePayload: ResolverTypeWrapper<Omit<PricePayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
   PricePoint: ResolverTypeWrapper<PricePoint>;
   PublicWallet: ResolverTypeWrapper<PublicWallet>;
   Query: ResolverTypeWrapper<{}>;
   Quiz: ResolverTypeWrapper<Quiz>;
   QuizClaimInput: QuizClaimInput;
-  QuizClaimPayload: ResolverTypeWrapper<QuizClaimPayload>;
+  QuizClaimPayload: ResolverTypeWrapper<Omit<QuizClaimPayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
   RealtimePrice: ResolverTypeWrapper<RealtimePrice>;
   RealtimePriceInput: RealtimePriceInput;
-  RealtimePricePayload: ResolverTypeWrapper<RealtimePricePayload>;
+  RealtimePricePayload: ResolverTypeWrapper<Omit<RealtimePricePayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
   SafeInt: ResolverTypeWrapper<Scalars['SafeInt']['output']>;
   SatAmount: ResolverTypeWrapper<Scalars['SatAmount']['output']>;
-  SatAmountPayload: ResolverTypeWrapper<SatAmountPayload>;
+  SatAmountPayload: ResolverTypeWrapper<Omit<SatAmountPayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
   Scope: Scope;
   Seconds: ResolverTypeWrapper<Scalars['Seconds']['output']>;
   SettlementVia: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['SettlementVia']>;
@@ -3691,13 +3692,13 @@ export type ResolversTypes = {
   SignedDisplayMajorAmount: ResolverTypeWrapper<Scalars['SignedDisplayMajorAmount']['output']>;
   StatefulNotification: ResolverTypeWrapper<Omit<StatefulNotification, 'action'> & { action?: Maybe<ResolversTypes['NotificationAction']> }>;
   StatefulNotificationAcknowledgeInput: StatefulNotificationAcknowledgeInput;
-  StatefulNotificationAcknowledgePayload: ResolverTypeWrapper<StatefulNotificationAcknowledgePayload>;
-  StatefulNotificationConnection: ResolverTypeWrapper<StatefulNotificationConnection>;
-  StatefulNotificationEdge: ResolverTypeWrapper<StatefulNotificationEdge>;
+  StatefulNotificationAcknowledgePayload: ResolverTypeWrapper<Omit<StatefulNotificationAcknowledgePayload, 'notification'> & { notification: ResolversTypes['StatefulNotification'] }>;
+  StatefulNotificationConnection: ResolverTypeWrapper<Omit<StatefulNotificationConnection, 'edges' | 'nodes'> & { edges: ReadonlyArray<ResolversTypes['StatefulNotificationEdge']>, nodes: ReadonlyArray<ResolversTypes['StatefulNotification']> }>;
+  StatefulNotificationEdge: ResolverTypeWrapper<Omit<StatefulNotificationEdge, 'node'> & { node: ResolversTypes['StatefulNotification'] }>;
   Subscription: ResolverTypeWrapper<{}>;
-  SuccessPayload: ResolverTypeWrapper<SuccessPayload>;
+  SuccessPayload: ResolverTypeWrapper<Omit<SuccessPayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
   SupportChatMessageAddInput: SupportChatMessageAddInput;
-  SupportChatMessageAddPayload: ResolverTypeWrapper<SupportChatMessageAddPayload>;
+  SupportChatMessageAddPayload: ResolverTypeWrapper<Omit<SupportChatMessageAddPayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
   SupportMessage: ResolverTypeWrapper<SupportMessage>;
   SupportRole: SupportRole;
   Timestamp: ResolverTypeWrapper<Scalars['Timestamp']['output']>;
@@ -3705,39 +3706,39 @@ export type ResolversTypes = {
   TotpRegistrationId: ResolverTypeWrapper<Scalars['TotpRegistrationId']['output']>;
   TotpSecret: ResolverTypeWrapper<Scalars['TotpSecret']['output']>;
   Transaction: ResolverTypeWrapper<Omit<Transaction, 'initiationVia' | 'settlementVia'> & { initiationVia: ResolversTypes['InitiationVia'], settlementVia: ResolversTypes['SettlementVia'] }>;
-  TransactionConnection: ResolverTypeWrapper<TransactionConnection>;
-  TransactionEdge: ResolverTypeWrapper<TransactionEdge>;
+  TransactionConnection: ResolverTypeWrapper<Omit<TransactionConnection, 'edges'> & { edges?: Maybe<ReadonlyArray<ResolversTypes['TransactionEdge']>> }>;
+  TransactionEdge: ResolverTypeWrapper<Omit<TransactionEdge, 'node'> & { node: ResolversTypes['Transaction'] }>;
   TxDirection: TxDirection;
   TxExternalId: ResolverTypeWrapper<Scalars['TxExternalId']['output']>;
   TxNotificationType: TxNotificationType;
   TxStatus: TxStatus;
-  UpgradePayload: ResolverTypeWrapper<UpgradePayload>;
-  UsdWallet: ResolverTypeWrapper<UsdWallet>;
-  User: ResolverTypeWrapper<User>;
-  UserContact: ResolverTypeWrapper<UserContact>;
+  UpgradePayload: ResolverTypeWrapper<Omit<UpgradePayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
+  UsdWallet: ResolverTypeWrapper<Omit<UsdWallet, 'invoiceByPaymentHash' | 'invoices' | 'pendingIncomingTransactions' | 'pendingIncomingTransactionsByAddress' | 'transactionById' | 'transactions' | 'transactionsByAddress' | 'transactionsByPaymentHash' | 'transactionsByPaymentRequest'> & { invoiceByPaymentHash: ResolversTypes['Invoice'], invoices?: Maybe<ResolversTypes['InvoiceConnection']>, pendingIncomingTransactions: ReadonlyArray<ResolversTypes['Transaction']>, pendingIncomingTransactionsByAddress: ReadonlyArray<ResolversTypes['Transaction']>, transactionById: ResolversTypes['Transaction'], transactions?: Maybe<ResolversTypes['TransactionConnection']>, transactionsByAddress?: Maybe<ResolversTypes['TransactionConnection']>, transactionsByPaymentHash: ReadonlyArray<ResolversTypes['Transaction']>, transactionsByPaymentRequest: ReadonlyArray<ResolversTypes['Transaction']> }>;
+  User: ResolverTypeWrapper<Omit<User, 'contactByUsername' | 'contacts' | 'defaultAccount' | 'statefulNotifications' | 'statefulNotificationsWithoutBulletinEnabled' | 'unacknowledgedStatefulNotificationsWithBulletinEnabled'> & { contactByUsername: ResolversTypes['UserContact'], contacts: ReadonlyArray<ResolversTypes['UserContact']>, defaultAccount: ResolversTypes['Account'], statefulNotifications: ResolversTypes['StatefulNotificationConnection'], statefulNotificationsWithoutBulletinEnabled: ResolversTypes['StatefulNotificationConnection'], unacknowledgedStatefulNotificationsWithBulletinEnabled: ResolversTypes['StatefulNotificationConnection'] }>;
+  UserContact: ResolverTypeWrapper<Omit<UserContact, 'transactions'> & { transactions?: Maybe<ResolversTypes['TransactionConnection']> }>;
   UserContactUpdateAliasInput: UserContactUpdateAliasInput;
-  UserContactUpdateAliasPayload: ResolverTypeWrapper<UserContactUpdateAliasPayload>;
-  UserEmailDeletePayload: ResolverTypeWrapper<UserEmailDeletePayload>;
+  UserContactUpdateAliasPayload: ResolverTypeWrapper<Omit<UserContactUpdateAliasPayload, 'contact' | 'errors'> & { contact?: Maybe<ResolversTypes['UserContact']>, errors: ReadonlyArray<ResolversTypes['Error']> }>;
+  UserEmailDeletePayload: ResolverTypeWrapper<Omit<UserEmailDeletePayload, 'errors' | 'me'> & { errors: ReadonlyArray<ResolversTypes['Error']>, me?: Maybe<ResolversTypes['User']> }>;
   UserEmailRegistrationInitiateInput: UserEmailRegistrationInitiateInput;
-  UserEmailRegistrationInitiatePayload: ResolverTypeWrapper<UserEmailRegistrationInitiatePayload>;
+  UserEmailRegistrationInitiatePayload: ResolverTypeWrapper<Omit<UserEmailRegistrationInitiatePayload, 'errors' | 'me'> & { errors: ReadonlyArray<ResolversTypes['Error']>, me?: Maybe<ResolversTypes['User']> }>;
   UserEmailRegistrationValidateInput: UserEmailRegistrationValidateInput;
-  UserEmailRegistrationValidatePayload: ResolverTypeWrapper<UserEmailRegistrationValidatePayload>;
+  UserEmailRegistrationValidatePayload: ResolverTypeWrapper<Omit<UserEmailRegistrationValidatePayload, 'errors' | 'me'> & { errors: ReadonlyArray<ResolversTypes['Error']>, me?: Maybe<ResolversTypes['User']> }>;
   UserLoginInput: UserLoginInput;
   UserLoginUpgradeInput: UserLoginUpgradeInput;
   UserLogoutInput: UserLogoutInput;
-  UserPhoneDeletePayload: ResolverTypeWrapper<UserPhoneDeletePayload>;
+  UserPhoneDeletePayload: ResolverTypeWrapper<Omit<UserPhoneDeletePayload, 'errors' | 'me'> & { errors: ReadonlyArray<ResolversTypes['Error']>, me?: Maybe<ResolversTypes['User']> }>;
   UserPhoneRegistrationInitiateInput: UserPhoneRegistrationInitiateInput;
   UserPhoneRegistrationValidateInput: UserPhoneRegistrationValidateInput;
-  UserPhoneRegistrationValidatePayload: ResolverTypeWrapper<UserPhoneRegistrationValidatePayload>;
-  UserTotpDeletePayload: ResolverTypeWrapper<UserTotpDeletePayload>;
-  UserTotpRegistrationInitiatePayload: ResolverTypeWrapper<UserTotpRegistrationInitiatePayload>;
+  UserPhoneRegistrationValidatePayload: ResolverTypeWrapper<Omit<UserPhoneRegistrationValidatePayload, 'errors' | 'me'> & { errors: ReadonlyArray<ResolversTypes['Error']>, me?: Maybe<ResolversTypes['User']> }>;
+  UserTotpDeletePayload: ResolverTypeWrapper<Omit<UserTotpDeletePayload, 'errors' | 'me'> & { errors: ReadonlyArray<ResolversTypes['Error']>, me?: Maybe<ResolversTypes['User']> }>;
+  UserTotpRegistrationInitiatePayload: ResolverTypeWrapper<Omit<UserTotpRegistrationInitiatePayload, 'errors'> & { errors: ReadonlyArray<ResolversTypes['Error']> }>;
   UserTotpRegistrationValidateInput: UserTotpRegistrationValidateInput;
-  UserTotpRegistrationValidatePayload: ResolverTypeWrapper<UserTotpRegistrationValidatePayload>;
+  UserTotpRegistrationValidatePayload: ResolverTypeWrapper<Omit<UserTotpRegistrationValidatePayload, 'errors' | 'me'> & { errors: ReadonlyArray<ResolversTypes['Error']>, me?: Maybe<ResolversTypes['User']> }>;
   UserUpdate: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>['UserUpdate']>;
   UserUpdateLanguageInput: UserUpdateLanguageInput;
-  UserUpdateLanguagePayload: ResolverTypeWrapper<UserUpdateLanguagePayload>;
+  UserUpdateLanguagePayload: ResolverTypeWrapper<Omit<UserUpdateLanguagePayload, 'errors' | 'user'> & { errors: ReadonlyArray<ResolversTypes['Error']>, user?: Maybe<ResolversTypes['User']> }>;
   UserUpdateUsernameInput: UserUpdateUsernameInput;
-  UserUpdateUsernamePayload: ResolverTypeWrapper<UserUpdateUsernamePayload>;
+  UserUpdateUsernamePayload: ResolverTypeWrapper<Omit<UserUpdateUsernamePayload, 'errors' | 'user'> & { errors: ReadonlyArray<ResolversTypes['Error']>, user?: Maybe<ResolversTypes['User']> }>;
   Username: ResolverTypeWrapper<Scalars['Username']['output']>;
   Wallet: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>['Wallet']>;
   WalletCurrency: WalletCurrency;
@@ -3754,39 +3755,39 @@ export type ResolversParentTypes = {
   String: Scalars['String']['output'];
   ID: Scalars['ID']['output'];
   Int: Scalars['Int']['output'];
-  AccountDeletePayload: AccountDeletePayload;
+  AccountDeletePayload: Omit<AccountDeletePayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
   Boolean: Scalars['Boolean']['output'];
   AccountDisableNotificationCategoryInput: AccountDisableNotificationCategoryInput;
   AccountDisableNotificationChannelInput: AccountDisableNotificationChannelInput;
   AccountEnableNotificationCategoryInput: AccountEnableNotificationCategoryInput;
   AccountEnableNotificationChannelInput: AccountEnableNotificationChannelInput;
   AccountLimit: ResolversInterfaceTypes<ResolversParentTypes>['AccountLimit'];
-  AccountLimits: AccountLimits;
+  AccountLimits: Omit<AccountLimits, 'convert' | 'internalSend' | 'withdrawal'> & { convert: ReadonlyArray<ResolversParentTypes['AccountLimit']>, internalSend: ReadonlyArray<ResolversParentTypes['AccountLimit']>, withdrawal: ReadonlyArray<ResolversParentTypes['AccountLimit']> };
   AccountUpdateDefaultWalletIdInput: AccountUpdateDefaultWalletIdInput;
-  AccountUpdateDefaultWalletIdPayload: AccountUpdateDefaultWalletIdPayload;
+  AccountUpdateDefaultWalletIdPayload: Omit<AccountUpdateDefaultWalletIdPayload, 'account' | 'errors'> & { account?: Maybe<ResolversParentTypes['ConsumerAccount']>, errors: ReadonlyArray<ResolversParentTypes['Error']> };
   AccountUpdateDisplayCurrencyInput: AccountUpdateDisplayCurrencyInput;
-  AccountUpdateDisplayCurrencyPayload: AccountUpdateDisplayCurrencyPayload;
-  AccountUpdateNotificationSettingsPayload: AccountUpdateNotificationSettingsPayload;
+  AccountUpdateDisplayCurrencyPayload: Omit<AccountUpdateDisplayCurrencyPayload, 'account' | 'errors'> & { account?: Maybe<ResolversParentTypes['ConsumerAccount']>, errors: ReadonlyArray<ResolversParentTypes['Error']> };
+  AccountUpdateNotificationSettingsPayload: Omit<AccountUpdateNotificationSettingsPayload, 'account' | 'errors'> & { account?: Maybe<ResolversParentTypes['ConsumerAccount']>, errors: ReadonlyArray<ResolversParentTypes['Error']> };
   ApiKey: ApiKey;
   ApiKeyCreateInput: ApiKeyCreateInput;
   ApiKeyCreatePayload: ApiKeyCreatePayload;
   ApiKeyRevokeInput: ApiKeyRevokeInput;
   ApiKeyRevokePayload: ApiKeyRevokePayload;
   AuthToken: Scalars['AuthToken']['output'];
-  AuthTokenPayload: AuthTokenPayload;
+  AuthTokenPayload: Omit<AuthTokenPayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
   Authorization: Authorization;
-  BTCWallet: BtcWallet;
+  BTCWallet: Omit<BtcWallet, 'invoiceByPaymentHash' | 'invoices' | 'pendingIncomingTransactions' | 'pendingIncomingTransactionsByAddress' | 'transactionById' | 'transactions' | 'transactionsByAddress' | 'transactionsByPaymentHash' | 'transactionsByPaymentRequest'> & { invoiceByPaymentHash: ResolversParentTypes['Invoice'], invoices?: Maybe<ResolversParentTypes['InvoiceConnection']>, pendingIncomingTransactions: ReadonlyArray<ResolversParentTypes['Transaction']>, pendingIncomingTransactionsByAddress: ReadonlyArray<ResolversParentTypes['Transaction']>, transactionById: ResolversParentTypes['Transaction'], transactions?: Maybe<ResolversParentTypes['TransactionConnection']>, transactionsByAddress?: Maybe<ResolversParentTypes['TransactionConnection']>, transactionsByPaymentHash: ReadonlyArray<ResolversParentTypes['Transaction']>, transactionsByPaymentRequest: ReadonlyArray<ResolversParentTypes['Transaction']> };
   BuildInformation: BuildInformation;
   CallbackEndpoint: CallbackEndpoint;
   CallbackEndpointAddInput: CallbackEndpointAddInput;
-  CallbackEndpointAddPayload: CallbackEndpointAddPayload;
+  CallbackEndpointAddPayload: Omit<CallbackEndpointAddPayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
   CallbackEndpointDeleteInput: CallbackEndpointDeleteInput;
-  CaptchaCreateChallengePayload: CaptchaCreateChallengePayload;
+  CaptchaCreateChallengePayload: Omit<CaptchaCreateChallengePayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
   CaptchaCreateChallengeResult: CaptchaCreateChallengeResult;
   CaptchaRequestAuthCodeInput: CaptchaRequestAuthCodeInput;
   CentAmount: Scalars['CentAmount']['output'];
-  CentAmountPayload: CentAmountPayload;
-  ConsumerAccount: ConsumerAccount;
+  CentAmountPayload: Omit<CentAmountPayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
+  ConsumerAccount: Omit<ConsumerAccount, 'callbackEndpoints' | 'invoices' | 'limits' | 'pendingIncomingTransactions' | 'transactions' | 'walletById' | 'wallets'> & { callbackEndpoints: ReadonlyArray<ResolversParentTypes['CallbackEndpoint']>, invoices?: Maybe<ResolversParentTypes['InvoiceConnection']>, limits: ResolversParentTypes['AccountLimits'], pendingIncomingTransactions: ReadonlyArray<ResolversParentTypes['Transaction']>, transactions?: Maybe<ResolversParentTypes['TransactionConnection']>, walletById: ResolversParentTypes['Wallet'], wallets: ReadonlyArray<ResolversParentTypes['Wallet']> };
   ContactAlias: Scalars['ContactAlias']['output'];
   Coordinates: Coordinates;
   Float: Scalars['Float']['output'];
@@ -3814,11 +3815,11 @@ export type ResolversParentTypes = {
   InitiationViaLn: InitiationViaLn;
   InitiationViaOnChain: InitiationViaOnChain;
   IntraLedgerPaymentSendInput: IntraLedgerPaymentSendInput;
-  IntraLedgerUpdate: IntraLedgerUpdate;
+  IntraLedgerUpdate: Omit<IntraLedgerUpdate, 'transaction'> & { transaction: ResolversParentTypes['Transaction'] };
   IntraLedgerUsdPaymentSendInput: IntraLedgerUsdPaymentSendInput;
   Invoice: ResolversInterfaceTypes<ResolversParentTypes>['Invoice'];
-  InvoiceConnection: InvoiceConnection;
-  InvoiceEdge: InvoiceEdge;
+  InvoiceConnection: Omit<InvoiceConnection, 'edges'> & { edges?: Maybe<ReadonlyArray<ResolversParentTypes['InvoiceEdge']>> };
+  InvoiceEdge: Omit<InvoiceEdge, 'node'> & { node: ResolversParentTypes['Invoice'] };
   Language: Scalars['Language']['output'];
   LnAddressPaymentSendInput: LnAddressPaymentSendInput;
   LnInvoice: LnInvoice;
@@ -3826,25 +3827,25 @@ export type ResolversParentTypes = {
   LnInvoiceCreateInput: LnInvoiceCreateInput;
   LnInvoiceCreateOnBehalfOfRecipientInput: LnInvoiceCreateOnBehalfOfRecipientInput;
   LnInvoiceFeeProbeInput: LnInvoiceFeeProbeInput;
-  LnInvoicePayload: LnInvoicePayload;
+  LnInvoicePayload: Omit<LnInvoicePayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
   LnInvoicePaymentInput: LnInvoicePaymentInput;
   LnInvoicePaymentStatus: LnInvoicePaymentStatus;
   LnInvoicePaymentStatusByHashInput: LnInvoicePaymentStatusByHashInput;
   LnInvoicePaymentStatusByPaymentRequestInput: LnInvoicePaymentStatusByPaymentRequestInput;
   LnInvoicePaymentStatusInput: LnInvoicePaymentStatusInput;
-  LnInvoicePaymentStatusPayload: LnInvoicePaymentStatusPayload;
+  LnInvoicePaymentStatusPayload: Omit<LnInvoicePaymentStatusPayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
   LnNoAmountInvoice: LnNoAmountInvoice;
   LnNoAmountInvoiceCreateInput: LnNoAmountInvoiceCreateInput;
   LnNoAmountInvoiceCreateOnBehalfOfRecipientInput: LnNoAmountInvoiceCreateOnBehalfOfRecipientInput;
   LnNoAmountInvoiceFeeProbeInput: LnNoAmountInvoiceFeeProbeInput;
-  LnNoAmountInvoicePayload: LnNoAmountInvoicePayload;
+  LnNoAmountInvoicePayload: Omit<LnNoAmountInvoicePayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
   LnNoAmountInvoicePaymentInput: LnNoAmountInvoicePaymentInput;
   LnNoAmountUsdInvoiceFeeProbeInput: LnNoAmountUsdInvoiceFeeProbeInput;
   LnNoAmountUsdInvoicePaymentInput: LnNoAmountUsdInvoicePaymentInput;
   LnPaymentPreImage: Scalars['LnPaymentPreImage']['output'];
   LnPaymentRequest: Scalars['LnPaymentRequest']['output'];
   LnPaymentSecret: Scalars['LnPaymentSecret']['output'];
-  LnUpdate: LnUpdate;
+  LnUpdate: Omit<LnUpdate, 'transaction'> & { transaction: ResolversParentTypes['Transaction'] };
   LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientInput: LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientInput;
   LnUsdInvoiceCreateInput: LnUsdInvoiceCreateInput;
   LnUsdInvoiceCreateOnBehalfOfRecipientInput: LnUsdInvoiceCreateOnBehalfOfRecipientInput;
@@ -3855,11 +3856,11 @@ export type ResolversParentTypes = {
   Memo: Scalars['Memo']['output'];
   Merchant: Merchant;
   MerchantMapSuggestInput: MerchantMapSuggestInput;
-  MerchantPayload: MerchantPayload;
+  MerchantPayload: Omit<MerchantPayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
   Minutes: Scalars['Minutes']['output'];
   MobileVersions: MobileVersions;
   Mutation: {};
-  MyUpdatesPayload: Omit<MyUpdatesPayload, 'update'> & { update?: Maybe<ResolversParentTypes['UserUpdate']> };
+  MyUpdatesPayload: Omit<MyUpdatesPayload, 'errors' | 'me' | 'update'> & { errors: ReadonlyArray<ResolversParentTypes['Error']>, me?: Maybe<ResolversParentTypes['User']>, update?: Maybe<ResolversParentTypes['UserUpdate']> };
   NotificationAction: ResolversUnionTypes<ResolversParentTypes>['NotificationAction'];
   NotificationCategory: Scalars['NotificationCategory']['output'];
   NotificationChannelSettings: NotificationChannelSettings;
@@ -3867,12 +3868,12 @@ export type ResolversParentTypes = {
   OnChainAddress: Scalars['OnChainAddress']['output'];
   OnChainAddressCreateInput: OnChainAddressCreateInput;
   OnChainAddressCurrentInput: OnChainAddressCurrentInput;
-  OnChainAddressPayload: OnChainAddressPayload;
+  OnChainAddressPayload: Omit<OnChainAddressPayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
   OnChainPaymentSendAllInput: OnChainPaymentSendAllInput;
   OnChainPaymentSendInput: OnChainPaymentSendInput;
   OnChainTxFee: OnChainTxFee;
   OnChainTxHash: Scalars['OnChainTxHash']['output'];
-  OnChainUpdate: OnChainUpdate;
+  OnChainUpdate: Omit<OnChainUpdate, 'transaction'> & { transaction: ResolversParentTypes['Transaction'] };
   OnChainUsdPaymentSendAsBtcDenominatedInput: OnChainUsdPaymentSendAsBtcDenominatedInput;
   OnChainUsdPaymentSendInput: OnChainUsdPaymentSendInput;
   OnChainUsdTxFee: OnChainUsdTxFee;
@@ -3882,7 +3883,7 @@ export type ResolversParentTypes = {
   OpenExternalLinkAction: OpenExternalLinkAction;
   PageInfo: PageInfo;
   PaymentHash: Scalars['PaymentHash']['output'];
-  PaymentSendPayload: PaymentSendPayload;
+  PaymentSendPayload: Omit<PaymentSendPayload, 'errors' | 'transaction'> & { errors: ReadonlyArray<ResolversParentTypes['Error']>, transaction?: Maybe<ResolversParentTypes['Transaction']> };
   PayoutSpeeds: PayoutSpeeds;
   Phone: Scalars['Phone']['output'];
   Price: Price;
@@ -3891,19 +3892,19 @@ export type ResolversParentTypes = {
   PriceOfOneSatInMinorUnit: PriceOfOneSatInMinorUnit;
   PriceOfOneSettlementMinorUnitInDisplayMinorUnit: PriceOfOneSettlementMinorUnitInDisplayMinorUnit;
   PriceOfOneUsdCentInMinorUnit: PriceOfOneUsdCentInMinorUnit;
-  PricePayload: PricePayload;
+  PricePayload: Omit<PricePayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
   PricePoint: PricePoint;
   PublicWallet: PublicWallet;
   Query: {};
   Quiz: Quiz;
   QuizClaimInput: QuizClaimInput;
-  QuizClaimPayload: QuizClaimPayload;
+  QuizClaimPayload: Omit<QuizClaimPayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
   RealtimePrice: RealtimePrice;
   RealtimePriceInput: RealtimePriceInput;
-  RealtimePricePayload: RealtimePricePayload;
+  RealtimePricePayload: Omit<RealtimePricePayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
   SafeInt: Scalars['SafeInt']['output'];
   SatAmount: Scalars['SatAmount']['output'];
-  SatAmountPayload: SatAmountPayload;
+  SatAmountPayload: Omit<SatAmountPayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
   Seconds: Scalars['Seconds']['output'];
   SettlementVia: ResolversUnionTypes<ResolversParentTypes>['SettlementVia'];
   SettlementViaIntraLedger: SettlementViaIntraLedger;
@@ -3913,49 +3914,49 @@ export type ResolversParentTypes = {
   SignedDisplayMajorAmount: Scalars['SignedDisplayMajorAmount']['output'];
   StatefulNotification: Omit<StatefulNotification, 'action'> & { action?: Maybe<ResolversParentTypes['NotificationAction']> };
   StatefulNotificationAcknowledgeInput: StatefulNotificationAcknowledgeInput;
-  StatefulNotificationAcknowledgePayload: StatefulNotificationAcknowledgePayload;
-  StatefulNotificationConnection: StatefulNotificationConnection;
-  StatefulNotificationEdge: StatefulNotificationEdge;
+  StatefulNotificationAcknowledgePayload: Omit<StatefulNotificationAcknowledgePayload, 'notification'> & { notification: ResolversParentTypes['StatefulNotification'] };
+  StatefulNotificationConnection: Omit<StatefulNotificationConnection, 'edges' | 'nodes'> & { edges: ReadonlyArray<ResolversParentTypes['StatefulNotificationEdge']>, nodes: ReadonlyArray<ResolversParentTypes['StatefulNotification']> };
+  StatefulNotificationEdge: Omit<StatefulNotificationEdge, 'node'> & { node: ResolversParentTypes['StatefulNotification'] };
   Subscription: {};
-  SuccessPayload: SuccessPayload;
+  SuccessPayload: Omit<SuccessPayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
   SupportChatMessageAddInput: SupportChatMessageAddInput;
-  SupportChatMessageAddPayload: SupportChatMessageAddPayload;
+  SupportChatMessageAddPayload: Omit<SupportChatMessageAddPayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
   SupportMessage: SupportMessage;
   Timestamp: Scalars['Timestamp']['output'];
   TotpCode: Scalars['TotpCode']['output'];
   TotpRegistrationId: Scalars['TotpRegistrationId']['output'];
   TotpSecret: Scalars['TotpSecret']['output'];
   Transaction: Omit<Transaction, 'initiationVia' | 'settlementVia'> & { initiationVia: ResolversParentTypes['InitiationVia'], settlementVia: ResolversParentTypes['SettlementVia'] };
-  TransactionConnection: TransactionConnection;
-  TransactionEdge: TransactionEdge;
+  TransactionConnection: Omit<TransactionConnection, 'edges'> & { edges?: Maybe<ReadonlyArray<ResolversParentTypes['TransactionEdge']>> };
+  TransactionEdge: Omit<TransactionEdge, 'node'> & { node: ResolversParentTypes['Transaction'] };
   TxExternalId: Scalars['TxExternalId']['output'];
-  UpgradePayload: UpgradePayload;
-  UsdWallet: UsdWallet;
-  User: User;
-  UserContact: UserContact;
+  UpgradePayload: Omit<UpgradePayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
+  UsdWallet: Omit<UsdWallet, 'invoiceByPaymentHash' | 'invoices' | 'pendingIncomingTransactions' | 'pendingIncomingTransactionsByAddress' | 'transactionById' | 'transactions' | 'transactionsByAddress' | 'transactionsByPaymentHash' | 'transactionsByPaymentRequest'> & { invoiceByPaymentHash: ResolversParentTypes['Invoice'], invoices?: Maybe<ResolversParentTypes['InvoiceConnection']>, pendingIncomingTransactions: ReadonlyArray<ResolversParentTypes['Transaction']>, pendingIncomingTransactionsByAddress: ReadonlyArray<ResolversParentTypes['Transaction']>, transactionById: ResolversParentTypes['Transaction'], transactions?: Maybe<ResolversParentTypes['TransactionConnection']>, transactionsByAddress?: Maybe<ResolversParentTypes['TransactionConnection']>, transactionsByPaymentHash: ReadonlyArray<ResolversParentTypes['Transaction']>, transactionsByPaymentRequest: ReadonlyArray<ResolversParentTypes['Transaction']> };
+  User: Omit<User, 'contactByUsername' | 'contacts' | 'defaultAccount' | 'statefulNotifications' | 'statefulNotificationsWithoutBulletinEnabled' | 'unacknowledgedStatefulNotificationsWithBulletinEnabled'> & { contactByUsername: ResolversParentTypes['UserContact'], contacts: ReadonlyArray<ResolversParentTypes['UserContact']>, defaultAccount: ResolversParentTypes['Account'], statefulNotifications: ResolversParentTypes['StatefulNotificationConnection'], statefulNotificationsWithoutBulletinEnabled: ResolversParentTypes['StatefulNotificationConnection'], unacknowledgedStatefulNotificationsWithBulletinEnabled: ResolversParentTypes['StatefulNotificationConnection'] };
+  UserContact: Omit<UserContact, 'transactions'> & { transactions?: Maybe<ResolversParentTypes['TransactionConnection']> };
   UserContactUpdateAliasInput: UserContactUpdateAliasInput;
-  UserContactUpdateAliasPayload: UserContactUpdateAliasPayload;
-  UserEmailDeletePayload: UserEmailDeletePayload;
+  UserContactUpdateAliasPayload: Omit<UserContactUpdateAliasPayload, 'contact' | 'errors'> & { contact?: Maybe<ResolversParentTypes['UserContact']>, errors: ReadonlyArray<ResolversParentTypes['Error']> };
+  UserEmailDeletePayload: Omit<UserEmailDeletePayload, 'errors' | 'me'> & { errors: ReadonlyArray<ResolversParentTypes['Error']>, me?: Maybe<ResolversParentTypes['User']> };
   UserEmailRegistrationInitiateInput: UserEmailRegistrationInitiateInput;
-  UserEmailRegistrationInitiatePayload: UserEmailRegistrationInitiatePayload;
+  UserEmailRegistrationInitiatePayload: Omit<UserEmailRegistrationInitiatePayload, 'errors' | 'me'> & { errors: ReadonlyArray<ResolversParentTypes['Error']>, me?: Maybe<ResolversParentTypes['User']> };
   UserEmailRegistrationValidateInput: UserEmailRegistrationValidateInput;
-  UserEmailRegistrationValidatePayload: UserEmailRegistrationValidatePayload;
+  UserEmailRegistrationValidatePayload: Omit<UserEmailRegistrationValidatePayload, 'errors' | 'me'> & { errors: ReadonlyArray<ResolversParentTypes['Error']>, me?: Maybe<ResolversParentTypes['User']> };
   UserLoginInput: UserLoginInput;
   UserLoginUpgradeInput: UserLoginUpgradeInput;
   UserLogoutInput: UserLogoutInput;
-  UserPhoneDeletePayload: UserPhoneDeletePayload;
+  UserPhoneDeletePayload: Omit<UserPhoneDeletePayload, 'errors' | 'me'> & { errors: ReadonlyArray<ResolversParentTypes['Error']>, me?: Maybe<ResolversParentTypes['User']> };
   UserPhoneRegistrationInitiateInput: UserPhoneRegistrationInitiateInput;
   UserPhoneRegistrationValidateInput: UserPhoneRegistrationValidateInput;
-  UserPhoneRegistrationValidatePayload: UserPhoneRegistrationValidatePayload;
-  UserTotpDeletePayload: UserTotpDeletePayload;
-  UserTotpRegistrationInitiatePayload: UserTotpRegistrationInitiatePayload;
+  UserPhoneRegistrationValidatePayload: Omit<UserPhoneRegistrationValidatePayload, 'errors' | 'me'> & { errors: ReadonlyArray<ResolversParentTypes['Error']>, me?: Maybe<ResolversParentTypes['User']> };
+  UserTotpDeletePayload: Omit<UserTotpDeletePayload, 'errors' | 'me'> & { errors: ReadonlyArray<ResolversParentTypes['Error']>, me?: Maybe<ResolversParentTypes['User']> };
+  UserTotpRegistrationInitiatePayload: Omit<UserTotpRegistrationInitiatePayload, 'errors'> & { errors: ReadonlyArray<ResolversParentTypes['Error']> };
   UserTotpRegistrationValidateInput: UserTotpRegistrationValidateInput;
-  UserTotpRegistrationValidatePayload: UserTotpRegistrationValidatePayload;
+  UserTotpRegistrationValidatePayload: Omit<UserTotpRegistrationValidatePayload, 'errors' | 'me'> & { errors: ReadonlyArray<ResolversParentTypes['Error']>, me?: Maybe<ResolversParentTypes['User']> };
   UserUpdate: ResolversUnionTypes<ResolversParentTypes>['UserUpdate'];
   UserUpdateLanguageInput: UserUpdateLanguageInput;
-  UserUpdateLanguagePayload: UserUpdateLanguagePayload;
+  UserUpdateLanguagePayload: Omit<UserUpdateLanguagePayload, 'errors' | 'user'> & { errors: ReadonlyArray<ResolversParentTypes['Error']>, user?: Maybe<ResolversParentTypes['User']> };
   UserUpdateUsernameInput: UserUpdateUsernameInput;
-  UserUpdateUsernamePayload: UserUpdateUsernamePayload;
+  UserUpdateUsernamePayload: Omit<UserUpdateUsernamePayload, 'errors' | 'user'> & { errors: ReadonlyArray<ResolversParentTypes['Error']>, user?: Maybe<ResolversParentTypes['User']> };
   Username: Scalars['Username']['output'];
   Wallet: ResolversInterfaceTypes<ResolversParentTypes>['Wallet'];
   WalletId: Scalars['WalletId']['output'];

--- a/apps/map/services/galoy/graphql/generated.ts
+++ b/apps/map/services/galoy/graphql/generated.ts
@@ -1619,6 +1619,7 @@ export type Quiz = {
 
 export type QuizClaimInput = {
   readonly id: Scalars['ID']['input'];
+  readonly skipRewards?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type QuizClaimPayload = {
@@ -2299,8 +2300,8 @@ export function useBusinessMapMarkersLazyQuery(baseOptions?: Apollo.LazyQueryHoo
           const options = {...defaultOptions, ...baseOptions}
           return Apollo.useLazyQuery<BusinessMapMarkersQuery, BusinessMapMarkersQueryVariables>(BusinessMapMarkersDocument, options);
         }
-export function useBusinessMapMarkersSuspenseQuery(baseOptions?: Apollo.SuspenseQueryHookOptions<BusinessMapMarkersQuery, BusinessMapMarkersQueryVariables>) {
-          const options = {...defaultOptions, ...baseOptions}
+export function useBusinessMapMarkersSuspenseQuery(baseOptions?: Apollo.SkipToken | Apollo.SuspenseQueryHookOptions<BusinessMapMarkersQuery, BusinessMapMarkersQueryVariables>) {
+          const options = baseOptions === Apollo.skipToken ? baseOptions : {...defaultOptions, ...baseOptions}
           return Apollo.useSuspenseQuery<BusinessMapMarkersQuery, BusinessMapMarkersQueryVariables>(BusinessMapMarkersDocument, options);
         }
 export type BusinessMapMarkersQueryHookResult = ReturnType<typeof useBusinessMapMarkersQuery>;

--- a/apps/pay/lib/graphql/generated.ts
+++ b/apps/pay/lib/graphql/generated.ts
@@ -1620,6 +1620,7 @@ export type Quiz = {
 
 export type QuizClaimInput = {
   readonly id: Scalars['ID']['input'];
+  readonly skipRewards?: InputMaybe<Scalars['Boolean']['input']>;
 };
 
 export type QuizClaimPayload = {

--- a/core/api/src/graphql/public/root/mutation/quiz-claim.ts
+++ b/core/api/src/graphql/public/root/mutation/quiz-claim.ts
@@ -8,13 +8,14 @@ const QuizClaimInput = GT.Input({
   name: "QuizClaimInput",
   fields: () => ({
     id: { type: GT.NonNull(GT.ID) },
+    skipRewards: { type: GT.Boolean },
   }),
 })
 
 const QuizClaimMutation = GT.Field<
   null,
   GraphQLPublicContextAuth,
-  { input: { id: string } }
+  { input: { id: string; skipRewards?: boolean } }
 >({
   extensions: {
     complexity: 120,
@@ -24,11 +25,12 @@ const QuizClaimMutation = GT.Field<
     input: { type: GT.NonNull(QuizClaimInput) },
   },
   resolve: async (_, args, { domainAccount, ip }) => {
-    const { id } = args.input
+    const { id, skipRewards = false } = args.input
 
     const quizzes = await Quiz.claimQuiz({
       quizQuestionId: id,
       accountId: domainAccount.id,
+      skipRewards,
       ip,
     })
     if (quizzes instanceof Error) {

--- a/core/api/src/graphql/public/root/mutation/quiz-claim.ts
+++ b/core/api/src/graphql/public/root/mutation/quiz-claim.ts
@@ -8,14 +8,14 @@ const QuizClaimInput = GT.Input({
   name: "QuizClaimInput",
   fields: () => ({
     id: { type: GT.NonNull(GT.ID) },
-    skipRewards: { type: GT.Boolean },
+    skipRewards: { type: GT.Boolean, defaultValue: false },
   }),
 })
 
 const QuizClaimMutation = GT.Field<
   null,
   GraphQLPublicContextAuth,
-  { input: { id: string; skipRewards?: boolean } }
+  { input: { id: string; skipRewards: boolean } }
 >({
   extensions: {
     complexity: 120,
@@ -25,7 +25,7 @@ const QuizClaimMutation = GT.Field<
     input: { type: GT.NonNull(QuizClaimInput) },
   },
   resolve: async (_, args, { domainAccount, ip }) => {
-    const { id, skipRewards = false } = args.input
+    const { id, skipRewards } = args.input
 
     const quizzes = await Quiz.claimQuiz({
       quizQuestionId: id,

--- a/core/api/src/graphql/public/schema.graphql
+++ b/core/api/src/graphql/public/schema.graphql
@@ -1305,6 +1305,7 @@ type Quiz {
 
 input QuizClaimInput {
   id: ID!
+  skipRewards: Boolean
 }
 
 type QuizClaimPayload {

--- a/core/api/src/graphql/public/schema.graphql
+++ b/core/api/src/graphql/public/schema.graphql
@@ -1305,7 +1305,7 @@ type Quiz {
 
 input QuizClaimInput {
   id: ID!
-  skipRewards: Boolean
+  skipRewards: Boolean = false
 }
 
 type QuizClaimPayload {

--- a/core/api/test/integration/app/quizzes/claim-quiz.spec.ts
+++ b/core/api/test/integration/app/quizzes/claim-quiz.spec.ts
@@ -12,6 +12,8 @@ import * as RateLimitImpl from "@/services/rate-limit"
 
 import { RateLimitConfig } from "@/domain/rate-limit"
 
+import { createRandomUserAndBtcWallet } from "test/helpers"
+
 afterEach(async () => {
   jest.restoreAllMocks()
 })
@@ -21,6 +23,7 @@ describe("addQuiz", () => {
     const result = await Quiz.claimQuiz({
       accountId: crypto.randomUUID() as AccountId,
       quizQuestionId: "fakeQuizQuestionId",
+      skipRewards: false,
       ip: undefined,
     })
     expect(result).toBeInstanceOf(InvalidIpMetadataError)
@@ -42,12 +45,51 @@ describe("addQuiz", () => {
     const result = await Quiz.claimQuiz({
       accountId: crypto.randomUUID() as AccountId,
       quizQuestionId: "fakeQuizQuestionId",
+      skipRewards: false,
       ip: "192.168.13.13" as IpAddress,
     })
 
     expect(result).toBeInstanceOf(AddQuizAttemptIpRateLimiterExceededError)
 
     // Restore system state
+    rateLimitServiceSpy.mockReset()
+  })
+
+  it("passes if ip is undefined and skipRewards is true", async () => {
+    const { accountId } = await createRandomUserAndBtcWallet()
+
+    const result = await Quiz.claimQuiz({
+      accountId,
+      quizQuestionId: "whoControlsBitcoin",
+      skipRewards: true,
+      ip: undefined,
+    })
+    expect(result).not.toBeInstanceOf(Error)
+  })
+
+  it("passes if ip limit hit but skipRewards is true", async () => {
+    const { RedisRateLimitService } = jest.requireActual("@/services/rate-limit")
+    const rateLimitServiceSpy = jest
+      .spyOn(RateLimitImpl, "RedisRateLimitService")
+      .mockReturnValue({
+        ...RedisRateLimitService({
+          keyPrefix: RateLimitConfig.addQuizAttemptPerIp.key,
+          limitOptions: RateLimitConfig.addQuizAttemptPerIp.limits,
+        }),
+        consume: () => new RateLimiterExceededError(),
+      })
+
+    const { accountId } = await createRandomUserAndBtcWallet()
+
+    const result = await Quiz.claimQuiz({
+      accountId,
+      quizQuestionId: "copyBitcoin",
+      skipRewards: true,
+      ip: "192.168.13.13" as IpAddress,
+    })
+
+    expect(result).not.toBeInstanceOf(Error)
+
     rateLimitServiceSpy.mockReset()
   })
 })

--- a/dev/config/apollo-federation/supergraph.graphql
+++ b/dev/config/apollo-federation/supergraph.graphql
@@ -1748,7 +1748,7 @@ input QuizClaimInput
   @join__type(graph: PUBLIC)
 {
   id: ID!
-  skipRewards: Boolean
+  skipRewards: Boolean = false
 }
 
 type QuizClaimPayload

--- a/dev/config/apollo-federation/supergraph.graphql
+++ b/dev/config/apollo-federation/supergraph.graphql
@@ -1748,6 +1748,7 @@ input QuizClaimInput
   @join__type(graph: PUBLIC)
 {
   id: ID!
+  skipRewards: Boolean
 }
 
 type QuizClaimPayload


### PR DESCRIPTION
## Description

This PR updates the quiz claim logic to support a `skipRewards` flag. When `skipRewards` is `true`, the system bypasses key validations and payment steps, allowing quiz completion without errors or rewards.

### Changes:
- Added `skipRewards` flag to the quiz claim input.
- When `skipRewards` is `true`, the following errors are omitted and no payment is processed:
  - `InvalidPhoneForQuizError` (Unsupported phone carrier)
  - `InvalidIpMetadataError` (Unsupported IP)
  - `QuizClaimedTooEarlyError` (Daily section limit)
  - `NotEnoughBalanceForQuizError` (Insufficient wallet funds)
- When `skipRewards` is `false`, all validations and payments occur as usual.
- Quizzes are marked as completed in both cases.