### PR TITLE
fix: adjust pattern matching for v2

### DIFF
--- a/core/api/src/services/twilio-service.ts
+++ b/core/api/src/services/twilio-service.ts
@@ -269,7 +269,7 @@ export const KnownTwilioErrorMessages = {
     /The destination phone number has been temporarily blocked by Twilio due to fraudulent activities/,
   ServiceUnavailable: /Service is unavailable. Please try again/,
   InvalidOrApprovedVerification:
-    /The requested resource \/Services\/(.*?)\/VerificationCheck was not found/,
+    /The requested resource \/(?:v2\/)?Services\/(.*?)\/VerificationCheck was not found/,
 } as const
 
 export const isPhoneCodeValid = async ({


### PR DESCRIPTION
I guess the pattern has been [introduced](https://github.com/blinkbitcoin/blink/commit/f99f6c61fe7e5d821f68762e2f84cfe0595c84a8) when we're still using v1 which was not versioned.

This PR should resolve a [lot of notifications](https://github.com/blinkbitcoin/blink-wip/wiki/onCallLog----2025%E2%80%9007%E2%80%9022-galoy%E2%80%90bbw%E2%80%90application%E2%80%90errors) from pagerduty.