### PR TITLE
fix(core): update level for MissingTypePhoneProviderError

### DIFF
--- a/core/api/src/domain/phone-provider/errors.ts
+++ b/core/api/src/domain/phone-provider/errors.ts
@@ -11,7 +11,7 @@ export class UnsubscribedRecipientPhoneProviderError extends PhoneProviderServic
 export class RestrictedRecipientPhoneNumberError extends PhoneProviderServiceError {}
 export class InvalidOrApprovedVerificationError extends PhoneProviderServiceError {}
 export class MissingTypePhoneProviderError extends PhoneProviderServiceError {
-  level = ErrorLevel.Critical
+  level = ErrorLevel.Warn
 }
 
 export class PhoneCodeInvalidError extends PhoneProviderServiceError {}


### PR DESCRIPTION
there is no actionable for this error unless it is a twilio crash but high warn or unknown error will trigger it