### PR TITLE
refactor: custom graphql errors to earn-section

### DIFF
--- a/core/api/src/graphql/error-map.ts
+++ b/core/api/src/graphql/error-map.ts
@@ -40,6 +40,10 @@ import {
   PriceServiceOfflineError,
   OperationRestrictedError,
   AuthorizationError,
+  InvalidIpMetadataError,
+  InvalidPhoneForQuizError,
+  NotEnoughBalanceForQuizError,
+  InvalidQuizQuestionIdError,
 } from "@/graphql/error"
 import { baseLogger } from "@/services/logger"
 
@@ -343,8 +347,8 @@ export const mapError = (error: ApplicationError): CustomGraphQLError => {
       return new TooManyRequestError({ message, logger: baseLogger })
 
     case "InvalidQuizQuestionIdError":
-      message = "Invalid quiz question id was passed."
-      return new ValidationInternalError({ message, logger: baseLogger })
+      message = error.message
+      return new InvalidQuizQuestionIdError({ message, logger: baseLogger })
 
     case "InvalidPushNotificationSettingError":
       message = "Invalid push notification setting was passed."
@@ -359,9 +363,8 @@ export const mapError = (error: ApplicationError): CustomGraphQLError => {
       return new ValidationInternalError({ message, logger: baseLogger })
 
     case "NotEnoughBalanceForQuizError":
-      message =
-        "Quiz wallet temporarily depleted. Please contact support if problem persists."
-      return new ValidationInternalError({ message, logger: baseLogger })
+      message = error.message
+      return new NotEnoughBalanceForQuizError({ message, logger: baseLogger })
 
     case "SubOneCentSatAmountForUsdSelfSendError":
     case "SubOneCentSatAmountForUsdReceiveError":
@@ -369,12 +372,12 @@ export const mapError = (error: ApplicationError): CustomGraphQLError => {
       return new ValidationInternalError({ message, logger: baseLogger })
 
     case "InvalidPhoneForQuizError":
-      message = "Unsupported phone carrier for quiz."
-      return new ValidationInternalError({ message, logger: baseLogger })
+      message = error.message
+      return new InvalidPhoneForQuizError({ message, logger: baseLogger })
 
     case "InvalidIpMetadataError":
-      message = "Unsupported IP."
-      return new ValidationInternalError({ message, logger: baseLogger })
+      message = error.message
+      return new InvalidIpMetadataError({ message, logger: baseLogger })
 
     case "NoConnectionToPriceServiceError":
       message = "Price unavailable, please wait for a while and try again."

--- a/core/api/src/graphql/error.ts
+++ b/core/api/src/graphql/error.ts
@@ -94,6 +94,51 @@ export class QuizClaimedTooEarlyError extends CustomGraphQLError {
   }
 }
 
+export class InvalidPhoneForQuizError extends CustomGraphQLError {
+  constructor(errData: CustomGraphQLErrorData) {
+    super({
+      ...errData,
+      code: "INVALID_PHONE_FOR_QUIZ",
+      forwardToClient: true,
+      message: "Unsupported phone carrier for quiz.",
+    })
+  }
+}
+
+export class InvalidIpMetadataError extends CustomGraphQLError {
+  constructor(errData: CustomGraphQLErrorData) {
+    super({
+      ...errData,
+      code: "INVALID_IP_METADATA",
+      forwardToClient: true,
+      message: "Unsupported IP.",
+    })
+  }
+}
+
+export class NotEnoughBalanceForQuizError extends CustomGraphQLError {
+  constructor(errData: CustomGraphQLErrorData) {
+    super({
+      ...errData,
+      code: "NOT_ENOUGH_BALANCE_FOR_QUIZ",
+      forwardToClient: true,
+      message:
+        "Quiz wallet temporarily depleted. Please contact support if problem persists.",
+    })
+  }
+}
+
+export class InvalidQuizQuestionIdError extends CustomGraphQLError {
+  constructor(errData: CustomGraphQLErrorData) {
+    super({
+      ...errData,
+      code: "INVALID_QUIZ_QUESTION_ID",
+      forwardToClient: true,
+      message: "Invalid quiz question id was passed.",
+    })
+  }
+}
+
 export class ValidationInternalError extends CustomGraphQLError {
   constructor(errData: CustomGraphQLErrorData) {
     super({ code: "INVALID_INPUT", forwardToClient: true, ...errData })


### PR DESCRIPTION
# New Quiz error codes

* **InvalidIpMetadataError** — `INVALID_IP_METADATA`
* **InvalidPhoneForQuizError** — `INVALID_PHONE_FOR_QUIZ`
* **NotEnoughBalanceForQuizError** — `NOT_ENOUGH_BALANCE_FOR_QUIZ`
* **InvalidQuizQuestionIdError** — `INVALID_QUIZ_QUESTION_ID`


</body></html>
<img width="2208" height="1024" alt="image" src="https://github.com/user-attachments/assets/77c2e3fe-c981-49f9-a0fd-4eeceefc1b3d" />
