### PR TITLE
fix: remove redundant check in settlement-via.ts

### DIFF
--- a/core/api/src/graphql/shared/types/abstract/settlement-via.ts
+++ b/core/api/src/graphql/shared/types/abstract/settlement-via.ts
@@ -36,11 +36,6 @@ const SettlementViaIntraLedger = GT.Object({
           return null
         }
 
-        const isSender = source.parent.settlementAmount > 0
-        if (isSender) {
-          return null
-        }
-
         const preImage = await Transactions.getInvoicePreImageByHash({
           paymentHash: source.parent.initiationVia.paymentHash,
         })


### PR DESCRIPTION
While querying transactions or invoices settled via intraledger, the preimage on the sender side was always null. Since payment status is already validated in Transactions.getInvoicePreImageByHash() (only a paid invoice returns a preimage), this additional check seemed redundant. The preimage is also exposed through the public LnInvoicePaymentStatusByHash query, so I’d propose removing the check.