### PR TITLE
fix: ensure lightning= parameter is lowercase in print QR code

### DIFF
--- a/apps/pay/app/[username]/print/page.tsx
+++ b/apps/pay/app/[username]/print/page.tsx
@@ -27,7 +27,7 @@ export default function Print({
     1500,
   )
   const webURL = `${url.protocol}//${url.host}/${username}`
-  const qrCodeURL = (webURL + "?lightning=" + lnurl).toUpperCase()
+  const qrCodeURL = webURL.toUpperCase() + "?lightning=" + lnurl.toUpperCase()
   const userHeader = `Pay ${username
     ?.toString()
     .toLowerCase()}@${getClientSidePayDomain()}`


### PR DESCRIPTION
## Summary

Fix LUD-01 fallback scheme violation where `lightning=` parameter is incorrectly uppercased to `LIGHTNING=` in the printable static QR code.

## Changes

- Keep `lightning=` parameter key lowercase while uppercasing the URL host/path and LNURL value
- Per [LUD-01 spec](https://github.com/lnurl/luds/blob/luds/01.md#fallback-scheme), the parameter key MUST be lowercase

## Testing

- Visual inspection of generated QR code URL
- This is a trivial string formatting change with no logic changes

## Related

Fixes blinkbitcoin/blink-mobile#3295

This is the same fix that was applied to the mobile app in PR #2521 for issue blinkbitcoin/blink-mobile#2520. The print page was not updated at that time.

---
Implementation plan: https://github.com/blinkbitcoin/blink-mobile/issues/3295#issuecomment-3707014171