### PR TITLE
fix(core): add unassigned_phone_number to known prelude errors

### DIFF
--- a/core/api/src/services/phone-provider/prelude-service.ts
+++ b/core/api/src/services/phone-provider/prelude-service.ts
@@ -188,6 +188,7 @@ const handleCommonErrors = (error: Error | string | unknown) => {
       case "impossible_code":
         return new PhoneCodeInvalidError()
       case "invalid_phone_number":
+      case "unassigned_phone_number":
         return new InvalidPhoneNumberPhoneProviderError(errMsg)
       case "invalid_line_type":
       case "invalid_phone_line": // legacy, keeping for backwards compatibility


### PR DESCRIPTION
fix `UnknownPhoneProviderServiceError` for `The provided phone number does not belong to a valid, assigned number range` error