### PR TITLE
fix(security): pin nodejs to 20.20.0 (CVE async_hooks DoS)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -71,6 +71,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-node": {
+      "locked": {
+        "lastModified": 1769433173,
+        "narHash": "sha256-Gf1dFYgD344WZ3q0LPlRoWaNdNQq8kSBDLEWulRQSEs=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "13b0f9e6ac78abbbb736c635d87845c4f4bee51b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1712666087,
@@ -92,6 +108,7 @@
         "concourse-shared": "concourse-shared",
         "flake-utils": "flake-utils_2",
         "nixpkgs": "nixpkgs_2",
+        "nixpkgs-node": "nixpkgs-node",
         "rust-overlay": "rust-overlay"
       }
     },


### PR DESCRIPTION
## Summary
- Add separate `nixpkgs-node` input pinned to latest nixpkgs-unstable (has nodejs_20 at 20.20.0)
- Use `nodePkgs.nodejs_20` in overlay instead of `super.nodejs_20`
- Add build-time assertion verifying nodejs version == 20.20.0
- Mitigates DoS via stack overflow in async_hooks (single request can crash service)

CVE: https://nodejs.org/en/blog/vulnerability/january-2026-dos-mitigation-async-hooks

The [Dockerfile](https://github.com/blinkbitcoin/blink/blob/main/core/api/Dockerfile) is using the nix-state from flake.nix.

## Why separate nixpkgs input?

We tried `overrideAttrs` to pin version directly, but:
1. nixpkgs patches for nodejs_20 don't apply cleanly to 20.20.0 source
2. With `patches = []`, builds from source → OOMs in Docker (V8 compilation)
3. No binary cache for custom-built node

The dual-input approach:
- Gets pre-built nodejs 20.20.0 from nix binary cache (fast, no compilation)
- Keeps main nixpkgs unchanged (no buck2/rust-overlay/Darwin SDK breakage)

## Verification
- [x] `nix develop -c node --version` = 20.20.0
- [x] `buck2 test //core/api:test` — 84 suites, 951 passed
- [x] Docker image build succeeds (fetches nodejs from cache)
- [x] CI passes
- [ ] Deploy staging + verify
- [ ] Deploy prod + verify

Refs: blinkbitcoin/blink-wip#391

🤖 Generated with [Claude Code](https://claude.com/claude-code)