### PR TITLE
chore(deps): update tilt to 0.36.3 via dedicated nixpkgs input

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -103,6 +103,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-tilt": {
+      "locked": {
+        "lastModified": 1771892004,
+        "narHash": "sha256-V96pa9awm6hjnf8yGJeoC4uOirYDEPsaBbuU0stROQI=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "5e4522be6bdf1600682a6f383434b057b2d77a37",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1712666087,
@@ -126,6 +142,7 @@
         "nixpkgs": "nixpkgs_2",
         "nixpkgs-docker": "nixpkgs-docker",
         "nixpkgs-node": "nixpkgs-node",
+        "nixpkgs-tilt": "nixpkgs-tilt",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -5,6 +5,7 @@
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     nixpkgs-node.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     nixpkgs-docker.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+    nixpkgs-tilt.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     concourse-shared.url = "github:blinkbitcoin/concourse-shared";
 
@@ -22,6 +23,7 @@
     nixpkgs,
     nixpkgs-node,
     nixpkgs-docker,
+    nixpkgs-tilt,
     flake-utils,
     concourse-shared,
     rust-overlay,
@@ -29,6 +31,7 @@
     flake-utils.lib.eachDefaultSystem (system: let
       nodePkgs = import nixpkgs-node {inherit system;};
       dockerPkgs = import nixpkgs-docker {inherit system;};
+      tiltPkgs = import nixpkgs-tilt {inherit system;};
       # CVE: DoS via stack overflow in async_hooks - require nodejs 20.20.0+
       expectedNodeVersion = "20.20.0";
       overlays = [
@@ -61,7 +64,7 @@
         [
           envsubst
           nodejs
-          tilt
+          tiltPkgs.tilt
           typescript
           bats
           postgresql


### PR DESCRIPTION
Docker daemon on nix host requires API v1.44+ but Tilt 0.33.10 embedded Docker client only supported v1.43. 
Add nixpkgs-tilt input (matching nixpkgs-docker/nixpkgs-node pattern) to get Tilt 0.36.3.