### PR TITLE
fix(core): block default wallet lookup for inactive accounts

### DIFF
--- a/core/api/src/app/accounts/get-wallet-from-account.ts
+++ b/core/api/src/app/accounts/get-wallet-from-account.ts
@@ -2,12 +2,17 @@ import {
   CouldNotFindDefaultWalletForAccount,
   CouldNotFindWalletForCurrency,
 } from "@/domain/errors"
+import { AccountValidator } from "@/domain/accounts"
+
 import { WalletsRepository } from "@/services/mongoose"
 
 export const getWalletFromAccount = async (
   account: Account,
   walletCurrency?: WalletCurrency,
 ): Promise<Wallet | ApplicationError> => {
+  const accountValidator = AccountValidator(account)
+  if (accountValidator instanceof Error) return accountValidator
+
   const wallets = await WalletsRepository().listByAccountId(account.id)
   if (wallets instanceof Error) return wallets
 


### PR DESCRIPTION
- Validate account status before resolving default wallet lookups
- Add Bats coverage for inactive account error on account-default-wallet