### PR TITLE
fix(notifications): correct 100x HUF amount in push notifications

### DIFF
--- a/core/notifications/src/notification_event/transaction_occurred.rs
+++ b/core/notifications/src/notification_event/transaction_occurred.rs
@@ -123,4 +123,26 @@ mod tests {
         assert_eq!(localized_message.title, "BTC Transaction");
         assert_eq!(localized_message.body, "+$0.04 | 1 sats");
     }
+
+    #[test]
+    fn lightning_receipt_huf_display_amount() {
+        // TypeScript sends HUF minor_units using Intl.NumberFormat (exponent=2):
+        // 248.07 Ft * 10^2 = 24807. After the fix in primitives.rs, this is divided
+        // by 10^(2-0)=100 before calling from_minor, giving 248 Ft — not 24807 Ft.
+        let event = TransactionOccurred {
+            transaction_type: TransactionType::LightningReceipt,
+            settlement_amount: TransactionAmount {
+                minor_units: 1111,
+                currency: Currency::Crypto(rusty_money::crypto::BTC),
+            },
+            display_amount: Some(TransactionAmount {
+                minor_units: 24807,
+                currency: Currency::Iso(rusty_money::iso::HUF),
+            }),
+        };
+        let localized_message = event.to_localized_push_msg(&GaloyLocale::from("en".to_string()));
+        assert_eq!(localized_message.title, "BTC Transaction");
+        // Should show 248 Ft (not 24,807 Ft which was the 100x bug)
+        assert_eq!(localized_message.body, "+248 Ft | 1111 sats");
+    }
 }

--- a/core/notifications/src/primitives.rs
+++ b/core/notifications/src/primitives.rs
@@ -180,6 +180,12 @@ impl Currency {
         round_to_major: bool,
     ) -> std::fmt::Result {
         match self {
+            Currency::Iso(c) if c.iso_alpha_code == "HUF" => {
+                // TypeScript sends HUF minor_units using Intl.NumberFormat (exponent=2),
+                // but rusty_money defines HUF with exponent=0. Divide by 100 to reconcile.
+                let adjusted = minor_units / 100;
+                write!(f, "{adjusted} Ft")
+            }
             Currency::Iso(c) => {
                 let money = if round_to_major {
                     rusty_money::Money::from_minor(minor_units as i64, *c)


### PR DESCRIPTION
## Problem

Push notifications for Bitcoin transactions display 100× the correct HUF
(Hungarian Forint) amount. For example, a transaction worth ~248 Ft is shown
as "+24 807Ft | 1111 sats" on the lock screen instead of "+248 Ft | 1111 sats".

## Root cause

The TypeScript API converts display amounts to minor units using
`Intl.NumberFormat`, which returns `minimumFractionDigits = 2` for HUF
(ISO 4217 defines fillér = 1/100 HUF). So 248.07 Ft is sent over gRPC as
`minor_units = 24807`.

However, `rusty_money` defines HUF with `exponent = 0` (no subdivision), so
`Money::from_minor(24807, HUF)` renders as "24807 Ft" — 100× too large.

## Fix

Add an explicit match arm for HUF in `Currency::format_minor_units` that
divides by 100 before formatting, and renders with a space before the symbol
(`"248 Ft"`) consistent with the BTC format (`"1111 sats"`).

No other currencies are affected.

## Test

Added `lightning_receipt_huf_display_amount` regression test in
`notification_event/transaction_occurred.rs` that feeds `minor_units = 24807`
for HUF and asserts the body is `"+248 Ft | 1111 sats"`.
