### PR TITLE
fix(admin-panel): remove change-level permission from supportlv1

### DIFF
--- a/apps/admin-panel/app/__tests__/access-rights.test.ts
+++ b/apps/admin-panel/app/__tests__/access-rights.test.ts
@@ -37,10 +37,9 @@ describe("Access Rights - Multiple Roles Support", () => {
           AdminAccessRight.LOCK_ACCOUNT,
           AdminAccessRight.APPROVE_MERCHANT,
           AdminAccessRight.VIEW_TRANSACTIONS,
-          AdminAccessRight.CHANGELEVEL_ACCOUNT,
         ]),
       )
-      expect(rights).toHaveLength(6)
+      expect(rights).toHaveLength(5)
     })
 
     test("getAccessRightsForRole returns correct rights for SUPPORTLV2", () => {
@@ -92,7 +91,7 @@ describe("Access Rights - Multiple Roles Support", () => {
       )
       expect(hasAccessRight("SUPPORTLV1", AdminAccessRight.APPROVE_MERCHANT)).toBe(true)
       expect(hasAccessRight("SUPPORTLV1", AdminAccessRight.CHANGELEVEL_ACCOUNT)).toBe(
-        true,
+        false,
       )
       expect(hasAccessRight("SUPPORTLV2", AdminAccessRight.CHANGELEVEL_ACCOUNT)).toBe(
         true,

--- a/apps/admin-panel/app/access-rights.ts
+++ b/apps/admin-panel/app/access-rights.ts
@@ -33,9 +33,12 @@ const SUPPORTLV1_RIGHTS = [
   ...VIEWER_RIGHTS,
   AdminAccessRight.LOCK_ACCOUNT,
   AdminAccessRight.APPROVE_MERCHANT,
-  AdminAccessRight.CHANGELEVEL_ACCOUNT,
 ]
-const SUPPORTLV2_RIGHTS = [...SUPPORTLV1_RIGHTS, AdminAccessRight.CHANGECONTACTS_ACCOUNT]
+const SUPPORTLV2_RIGHTS = [
+  ...SUPPORTLV1_RIGHTS,
+  AdminAccessRight.CHANGELEVEL_ACCOUNT,
+  AdminAccessRight.CHANGECONTACTS_ACCOUNT,
+]
 
 // ADMIN has all rights
 const ADMIN_RIGHTS = Object.values(AdminAccessRight)

--- a/apps/admin-panel/app/account/[uuid]/page.tsx
+++ b/apps/admin-panel/app/account/[uuid]/page.tsx
@@ -6,9 +6,11 @@ import {
   AccountDetailsByAccountIdQuery,
   AccountDetailsByAccountIdQueryVariables,
 } from "../../../generated"
+import { getScope } from "../../authz"
 import { getClient } from "../../graphql-rsc"
 
 export default async function AccountDetails({ params }: { params: { uuid: string } }) {
+  const scope = await getScope()
   const { data } = await getClient().query<
     AccountDetailsByAccountIdQuery,
     AccountDetailsByAccountIdQueryVariables
@@ -28,7 +30,7 @@ export default async function AccountDetails({ params }: { params: { uuid: strin
         <div className="grid gap-6 mb-8 md:grid-cols-2 p-6">
           <Details auditedAccount={auditedAccount} />
           <div className="grid grid-cols-1 gap-4">
-            <AccountUpdate auditedAccount={auditedAccount} />
+            <AccountUpdate auditedAccount={auditedAccount} scope={scope} />
           </div>
         </div>
         <Merchants merchants={auditedAccount.merchants} />

--- a/apps/admin-panel/app/authz.ts
+++ b/apps/admin-panel/app/authz.ts
@@ -1,0 +1,13 @@
+import { getServerSession } from "next-auth"
+
+import { authOptions } from "./api/auth/[...nextauth]/options"
+import { AdminAccessRight, hasAccessRightInScope } from "./access-rights"
+
+export const getScope = async (): Promise<string> => {
+  const session = await getServerSession(authOptions)
+  return session?.scope ?? ""
+}
+
+export const hasAccess = (scope: string, accessRight: AdminAccessRight): boolean => {
+  return hasAccessRightInScope(scope, accessRight)
+}

--- a/apps/admin-panel/app/layout.tsx
+++ b/apps/admin-panel/app/layout.tsx
@@ -5,12 +5,15 @@ import { Metadata } from "next"
 
 import SideBar from "../components/side-bar"
 
+import { getScope } from "./authz"
+
 export const metadata: Metadata = {
   title: "Admin Panel",
   description: "Welcome to Galoy Admin Panel",
 }
 
-export default function RootLayout({ children }: { children: React.ReactNode }) {
+export default async function RootLayout({ children }: { children: React.ReactNode }) {
+  const scope = await getScope()
   const year = new Date().getFullYear()
   return (
     <html lang="en">
@@ -18,7 +21,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
 
       <body>
         <div className="flex h-screen bg-gray-50">
-          <SideBar />
+          <SideBar scope={scope} />
           <div className="flex flex-col flex-1 w-full">
             <main className="h-full overflow-y-auto">
               <div className="container grid mx-auto">{children}</div>

--- a/apps/admin-panel/components/account/update.tsx
+++ b/apps/admin-panel/components/account/update.tsx
@@ -1,5 +1,7 @@
 import { revalidatePath } from "next/cache"
 
+import { AdminAccessRight } from "../../app/access-rights"
+import { hasAccess } from "../../app/authz"
 import { getClient } from "../../app/graphql-rsc"
 import {
   AccountDetailsByAccountIdDocument,
@@ -20,6 +22,7 @@ import { AuditedAccountMainValues } from "../../app/types"
 
 type PropType = {
   auditedAccount: AuditedAccountMainValues
+  scope: string
 }
 
 const updateLevel = async (formData: FormData) => {
@@ -78,9 +81,11 @@ const updateStatus = async (formData: FormData) => {
   revalidatePath("/account")
 }
 
-const AccountUpdate: React.FC<PropType> = ({ auditedAccount }) => {
+const AccountUpdate: React.FC<PropType> = ({ auditedAccount, scope }) => {
   const isActiveStatus = auditedAccount.status === "ACTIVE"
   const statusButtonLabel = isActiveStatus ? "Lock" : "Activate"
+  const canChangeLevel = hasAccess(scope, AdminAccessRight.CHANGELEVEL_ACCOUNT)
+  const canLockAccount = hasAccess(scope, AdminAccessRight.LOCK_ACCOUNT)
 
   return (
     <div className="shadow p-6 min-w-0 rounded-lg shadow-xs overflow-hidden bg-white grid grid-cols-2 gap-4">
@@ -95,7 +100,10 @@ const AccountUpdate: React.FC<PropType> = ({ auditedAccount }) => {
             >
               <input type="hidden" name="id" value={auditedAccount.id} />
               <input type="hidden" name="level" value={AccountLevel.Two} />
-              <button className="text-sm mx-4 bg-green-500 hover:bg-green-700 text-white font-bold p-2 border border-green-700 rounded disabled:opacity-50">
+              <button
+                disabled={!canChangeLevel}
+                className="text-sm mx-4 bg-green-500 hover:bg-green-700 text-white font-bold p-2 border border-green-700 rounded disabled:opacity-50"
+              >
                 {"Upgrade"}
               </button>
             </ConfirmForm>
@@ -113,7 +121,10 @@ const AccountUpdate: React.FC<PropType> = ({ auditedAccount }) => {
                   auditedAccount.level === "THREE" ? AccountLevel.Two : AccountLevel.One
                 }
               />
-              <button className="text-sm mx-4 bg-green-500 hover:bg-green-700 text-white font-bold p-2 border border-green-700 rounded disabled:opacity-50">
+              <button
+                disabled={!canChangeLevel}
+                className="text-sm mx-4 bg-green-500 hover:bg-green-700 text-white font-bold p-2 border border-green-700 rounded disabled:opacity-50"
+              >
                 {"Downgrade"}
               </button>
             </ConfirmForm>
@@ -131,6 +142,7 @@ const AccountUpdate: React.FC<PropType> = ({ auditedAccount }) => {
             >
               <input type="hidden" name="id" value={auditedAccount.id} />
               <button
+                disabled={!canLockAccount}
                 className={`text-sm mx-4 ${
                   isActiveStatus
                     ? "bg-red-500 hover:bg-red-700 border-red-700"

--- a/apps/admin-panel/components/side-bar.tsx
+++ b/apps/admin-panel/components/side-bar.tsx
@@ -6,6 +6,9 @@ import { usePathname } from "next/navigation"
 
 import { signOut } from "next-auth/react"
 
+import { AdminAccessRight } from "../app/access-rights"
+import { hasAccess } from "../app/authz"
+
 import PeopleIcon from "./icons/people.svg"
 import TransactionsIcon from "./icons/transactions.svg"
 import GlobeIcon from "./icons/search-globe.svg"
@@ -17,26 +20,33 @@ const dashboardRoutes = [
     name: "Account details",
     icon: PeopleIcon,
     path: "/account",
+    accessRight: AdminAccessRight.VIEW_ACCOUNTS,
   },
   {
     name: "Transactions",
     icon: TransactionsIcon,
     path: "/transactions",
+    accessRight: AdminAccessRight.VIEW_TRANSACTIONS,
   },
   {
     name: "Merchants",
     icon: GlobeIcon,
     path: "/merchants",
+    accessRight: AdminAccessRight.VIEW_MERCHANTS,
   },
   {
     name: "Notifications",
     icon: ComposeIcon,
     path: "/notifications",
+    accessRight: AdminAccessRight.SEND_NOTIFICATIONS,
   },
 ]
 
-function SideBar() {
+function SideBar({ scope }: { scope: string }) {
   const pathname = usePathname()
+  const visibleRoutes = dashboardRoutes.filter((route) =>
+    hasAccess(scope, route.accessRight),
+  )
 
   return (
     <aside className="z-30 flex-shrink-0 hidden w-64 overflow-y-auto bg-white lg:block">
@@ -57,7 +67,7 @@ function SideBar() {
           Admin Panel
         </Link>
         <ul className="mt-6">
-          {dashboardRoutes.map((route) => (
+          {visibleRoutes.map((route) => (
             <li className="relative px-6 py-3" key={route.name}>
               <Link
                 href={route.path}


### PR DESCRIPTION
## Summary
- align admin-panel role rights with intended policy: SUPPORTLV1 cannot change account level
- keep CHANGELEVEL_ACCOUNT permission on SUPPORTLV2 and update unit tests accordingly