### PR TITLE
fix(admin-panel): avoid server env access in client authz

### DIFF
--- a/apps/admin-panel/app/api/auth/[...nextauth]/options.ts
+++ b/apps/admin-panel/app/api/auth/[...nextauth]/options.ts
@@ -24,6 +24,7 @@ const DEV_CREDENTIALS: Record<string, { id: string; name: string; email: string 
   admin: { id: "1", name: "admin", email: "admintest@blinkbitcoin.test" },
   alice: { id: "2", name: "alice", email: "alicetest@blinkbitcoin.test" },
   bob: { id: "3", name: "bob", email: "bobtest@blinkbitcoin.test" },
+  carol: { id: "4", name: "carol", email: "caroltest@blinkbitcoin.test" },
 }
 
 const DEV_ROLE_MAPPING: Record<string, string[]> = {
@@ -33,19 +34,23 @@ const DEV_ROLE_MAPPING: Record<string, string[]> = {
   "caroltest@blinkbitcoin.test": ["SUPPORTLV2", "MARKETING_GLOBAL"],
 }
 
-const providers: Provider[] = [
-  GoogleProvider({
-    clientId: env.GOOGLE_CLIENT_ID ?? "",
-    clientSecret: env.GOOGLE_CLIENT_SECRET ?? "",
-    authorization: {
-      params: {
-        prompt: "consent",
-        access_type: "offline",
-        response_type: "code",
+const providers: Provider[] = []
+
+if (env.NODE_ENV !== "development") {
+  providers.push(
+    GoogleProvider({
+      clientId: env.GOOGLE_CLIENT_ID ?? "",
+      clientSecret: env.GOOGLE_CLIENT_SECRET ?? "",
+      authorization: {
+        params: {
+          prompt: "consent",
+          access_type: "offline",
+          response_type: "code",
+        },
       },
-    },
-  }),
-]
+    }),
+  )
+}
 
 if (env.NODE_ENV === "development") {
   providers.push(

--- a/apps/admin-panel/app/authz.ts
+++ b/apps/admin-panel/app/authz.ts
@@ -1,13 +1,11 @@
+// eslint-disable-next-line import/no-unassigned-import
+import "server-only"
+
 import { getServerSession } from "next-auth"
 
 import { authOptions } from "./api/auth/[...nextauth]/options"
-import { AdminAccessRight, hasAccessRightInScope } from "./access-rights"
 
 export const getScope = async (): Promise<string> => {
   const session = await getServerSession(authOptions)
   return session?.scope ?? ""
-}
-
-export const hasAccess = (scope: string, accessRight: AdminAccessRight): boolean => {
-  return hasAccessRightInScope(scope, accessRight)
 }

--- a/apps/admin-panel/app/scope-access.ts
+++ b/apps/admin-panel/app/scope-access.ts
@@ -1,0 +1,5 @@
+import { AdminAccessRight, hasAccessRightInScope } from "./access-rights"
+
+export const hasAccess = (scope: string, accessRight: AdminAccessRight): boolean => {
+  return hasAccessRightInScope(scope, accessRight)
+}

--- a/apps/admin-panel/components/account/update.tsx
+++ b/apps/admin-panel/components/account/update.tsx
@@ -1,7 +1,7 @@
 import { revalidatePath } from "next/cache"
 
 import { AdminAccessRight } from "../../app/access-rights"
-import { hasAccess } from "../../app/authz"
+import { hasAccess } from "../../app/scope-access"
 import { getClient } from "../../app/graphql-rsc"
 import {
   AccountDetailsByAccountIdDocument,

--- a/apps/admin-panel/components/side-bar.tsx
+++ b/apps/admin-panel/components/side-bar.tsx
@@ -7,7 +7,7 @@ import { usePathname } from "next/navigation"
 import { signOut } from "next-auth/react"
 
 import { AdminAccessRight } from "../app/access-rights"
-import { hasAccess } from "../app/authz"
+import { hasAccess } from "../app/scope-access"
 
 import PeopleIcon from "./icons/people.svg"
 import TransactionsIcon from "./icons/transactions.svg"


### PR DESCRIPTION
## Summary
- split scope helpers into server-only `getScope` and client-safe `hasAccess` utilities
- update sidebar/account UI permission checks to use the client-safe helper
- adjust auth provider setup for development credential login path