### PR TITLE
feat(api): add public invoice webhooks

### DIFF
--- a/apps/admin-panel/generated.ts
+++ b/apps/admin-panel/generated.ts
@@ -511,10 +511,12 @@ export const NotificationIcon = {
 export type NotificationIcon = typeof NotificationIcon[keyof typeof NotificationIcon];
 export type OpenDeepLinkInput = {
   readonly action?: InputMaybe<DeepLinkAction>;
+  readonly label?: InputMaybe<Scalars['String']['input']>;
   readonly screen?: InputMaybe<DeepLinkScreen>;
 };
 
 export type OpenExternalUrlInput = {
+  readonly label?: InputMaybe<Scalars['String']['input']>;
   readonly url: Scalars['ExternalUrl']['input'];
 };
 

--- a/apps/consent/app/graphql/generated.ts
+++ b/apps/consent/app/graphql/generated.ts
@@ -709,6 +709,7 @@ export type LnInvoiceCreateOnBehalfOfRecipientInput = {
   readonly memo?: InputMaybe<Scalars['Memo']['input']>;
   /** Wallet ID for a BTC wallet which belongs to any account. */
   readonly recipientWalletId: Scalars['WalletId']['input'];
+  readonly webhookUrl?: InputMaybe<Scalars['EndpointUrl']['input']>;
 };
 
 export type LnInvoiceFeeProbeInput = {
@@ -788,6 +789,7 @@ export type LnNoAmountInvoiceCreateOnBehalfOfRecipientInput = {
   readonly memo?: InputMaybe<Scalars['Memo']['input']>;
   /** ID for either a USD or BTC wallet which belongs to the account of any user. */
   readonly recipientWalletId: Scalars['WalletId']['input'];
+  readonly webhookUrl?: InputMaybe<Scalars['EndpointUrl']['input']>;
 };
 
 export type LnNoAmountInvoiceFeeProbeInput = {
@@ -851,6 +853,7 @@ export type LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientInput = {
   readonly memo?: InputMaybe<Scalars['Memo']['input']>;
   /** Wallet ID for a USD wallet which belongs to the account of any user. */
   readonly recipientWalletId: Scalars['WalletId']['input'];
+  readonly webhookUrl?: InputMaybe<Scalars['EndpointUrl']['input']>;
 };
 
 export type LnUsdInvoiceCreateInput = {
@@ -876,6 +879,7 @@ export type LnUsdInvoiceCreateOnBehalfOfRecipientInput = {
   readonly memo?: InputMaybe<Scalars['Memo']['input']>;
   /** Wallet ID for a USD wallet which belongs to the account of any user. */
   readonly recipientWalletId: Scalars['WalletId']['input'];
+  readonly webhookUrl?: InputMaybe<Scalars['EndpointUrl']['input']>;
 };
 
 export type LnUsdInvoiceFeeProbeInput = {

--- a/apps/dashboard/services/graphql/generated.ts
+++ b/apps/dashboard/services/graphql/generated.ts
@@ -841,6 +841,7 @@ export type LnInvoiceCreateOnBehalfOfRecipientInput = {
   readonly memo?: InputMaybe<Scalars['Memo']['input']>;
   /** Wallet ID for a BTC wallet which belongs to any account. */
   readonly recipientWalletId: Scalars['WalletId']['input'];
+  readonly webhookUrl?: InputMaybe<Scalars['EndpointUrl']['input']>;
 };
 
 export type LnInvoiceFeeProbeInput = {
@@ -920,6 +921,7 @@ export type LnNoAmountInvoiceCreateOnBehalfOfRecipientInput = {
   readonly memo?: InputMaybe<Scalars['Memo']['input']>;
   /** ID for either a USD or BTC wallet which belongs to the account of any user. */
   readonly recipientWalletId: Scalars['WalletId']['input'];
+  readonly webhookUrl?: InputMaybe<Scalars['EndpointUrl']['input']>;
 };
 
 export type LnNoAmountInvoiceFeeProbeInput = {
@@ -983,6 +985,7 @@ export type LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientInput = {
   readonly memo?: InputMaybe<Scalars['Memo']['input']>;
   /** Wallet ID for a USD wallet which belongs to the account of any user. */
   readonly recipientWalletId: Scalars['WalletId']['input'];
+  readonly webhookUrl?: InputMaybe<Scalars['EndpointUrl']['input']>;
 };
 
 export type LnUsdInvoiceCreateInput = {
@@ -1008,6 +1011,7 @@ export type LnUsdInvoiceCreateOnBehalfOfRecipientInput = {
   readonly memo?: InputMaybe<Scalars['Memo']['input']>;
   /** Wallet ID for a USD wallet which belongs to the account of any user. */
   readonly recipientWalletId: Scalars['WalletId']['input'];
+  readonly webhookUrl?: InputMaybe<Scalars['EndpointUrl']['input']>;
 };
 
 export type LnUsdInvoiceFeeProbeInput = {

--- a/apps/map/services/galoy/graphql/generated.ts
+++ b/apps/map/services/galoy/graphql/generated.ts
@@ -709,6 +709,7 @@ export type LnInvoiceCreateOnBehalfOfRecipientInput = {
   readonly memo?: InputMaybe<Scalars['Memo']['input']>;
   /** Wallet ID for a BTC wallet which belongs to any account. */
   readonly recipientWalletId: Scalars['WalletId']['input'];
+  readonly webhookUrl?: InputMaybe<Scalars['EndpointUrl']['input']>;
 };
 
 export type LnInvoiceFeeProbeInput = {
@@ -788,6 +789,7 @@ export type LnNoAmountInvoiceCreateOnBehalfOfRecipientInput = {
   readonly memo?: InputMaybe<Scalars['Memo']['input']>;
   /** ID for either a USD or BTC wallet which belongs to the account of any user. */
   readonly recipientWalletId: Scalars['WalletId']['input'];
+  readonly webhookUrl?: InputMaybe<Scalars['EndpointUrl']['input']>;
 };
 
 export type LnNoAmountInvoiceFeeProbeInput = {
@@ -851,6 +853,7 @@ export type LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientInput = {
   readonly memo?: InputMaybe<Scalars['Memo']['input']>;
   /** Wallet ID for a USD wallet which belongs to the account of any user. */
   readonly recipientWalletId: Scalars['WalletId']['input'];
+  readonly webhookUrl?: InputMaybe<Scalars['EndpointUrl']['input']>;
 };
 
 export type LnUsdInvoiceCreateInput = {
@@ -876,6 +879,7 @@ export type LnUsdInvoiceCreateOnBehalfOfRecipientInput = {
   readonly memo?: InputMaybe<Scalars['Memo']['input']>;
   /** Wallet ID for a USD wallet which belongs to the account of any user. */
   readonly recipientWalletId: Scalars['WalletId']['input'];
+  readonly webhookUrl?: InputMaybe<Scalars['EndpointUrl']['input']>;
 };
 
 export type LnUsdInvoiceFeeProbeInput = {

--- a/apps/pay/lib/graphql/generated.ts
+++ b/apps/pay/lib/graphql/generated.ts
@@ -710,6 +710,7 @@ export type LnInvoiceCreateOnBehalfOfRecipientInput = {
   readonly memo?: InputMaybe<Scalars['Memo']['input']>;
   /** Wallet ID for a BTC wallet which belongs to any account. */
   readonly recipientWalletId: Scalars['WalletId']['input'];
+  readonly webhookUrl?: InputMaybe<Scalars['EndpointUrl']['input']>;
 };
 
 export type LnInvoiceFeeProbeInput = {
@@ -789,6 +790,7 @@ export type LnNoAmountInvoiceCreateOnBehalfOfRecipientInput = {
   readonly memo?: InputMaybe<Scalars['Memo']['input']>;
   /** ID for either a USD or BTC wallet which belongs to the account of any user. */
   readonly recipientWalletId: Scalars['WalletId']['input'];
+  readonly webhookUrl?: InputMaybe<Scalars['EndpointUrl']['input']>;
 };
 
 export type LnNoAmountInvoiceFeeProbeInput = {
@@ -852,6 +854,7 @@ export type LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientInput = {
   readonly memo?: InputMaybe<Scalars['Memo']['input']>;
   /** Wallet ID for a USD wallet which belongs to the account of any user. */
   readonly recipientWalletId: Scalars['WalletId']['input'];
+  readonly webhookUrl?: InputMaybe<Scalars['EndpointUrl']['input']>;
 };
 
 export type LnUsdInvoiceCreateInput = {
@@ -877,6 +880,7 @@ export type LnUsdInvoiceCreateOnBehalfOfRecipientInput = {
   readonly memo?: InputMaybe<Scalars['Memo']['input']>;
   /** Wallet ID for a USD wallet which belongs to the account of any user. */
   readonly recipientWalletId: Scalars['WalletId']['input'];
+  readonly webhookUrl?: InputMaybe<Scalars['EndpointUrl']['input']>;
 };
 
 export type LnUsdInvoiceFeeProbeInput = {

--- a/bats/core/api/public-ln-receive.bats
+++ b/bats/core/api/public-ln-receive.bats
@@ -27,6 +27,24 @@ teardown() {
 btc_amount=1000
 usd_amount=50
 
+assert_terminal_invoice_webhook() {
+  local payment_hash=$1
+  local payment_request=$2
+  local preimage=$3
+  local wallet_id=$4
+
+  retry 15 1 grep "callback │ .*$payment_hash" "$TILT_LOG_FILE"
+  retry 15 1 grep "callback │ .*$payment_request" "$TILT_LOG_FILE"
+  retry 15 1 grep "callback │ .*PAID" "$TILT_LOG_FILE"
+  retry 15 1 grep "callback │ .*$preimage" "$TILT_LOG_FILE"
+
+  ! cat_callback | grep "$payment_hash" | grep -q "accountId" || exit 1
+  ! cat_callback | grep "$payment_hash" | grep -q "walletId" || exit 1
+  ! cat_callback | grep "$payment_hash" | grep -q "transaction" || exit 1
+  ! cat_callback | grep "$payment_hash" | grep -q "externalId" || exit 1
+  ! cat_callback | grep "$payment_hash" | grep -q "$wallet_id" || exit 1
+}
+
 @test "public-ln-receive: account details - can fetch with btc default wallet-id from username" {
   token_name=$ALICE
   btc_wallet_name="$token_name.btc_wallet_id"
@@ -315,16 +333,109 @@ usd_amount=50
   preimage="$(echo "$payment_result" | jq -r '.payment_preimage')"
 
   retry 15 1 check_ln_payment_settled_by_hash "$payment_request" "$payment_hash"
-  retry 15 1 grep "callback │ .*$payment_hash" "$TILT_LOG_FILE"
-  retry 15 1 grep "callback │ .*$payment_request" "$TILT_LOG_FILE"
-  retry 15 1 grep "callback │ .*PAID" "$TILT_LOG_FILE"
-  retry 15 1 grep "callback │ .*$preimage" "$TILT_LOG_FILE"
+  assert_terminal_invoice_webhook \
+    "$payment_hash" \
+    "$payment_request" \
+    "$preimage" \
+    "$btc_wallet_id"
+}
 
-  ! cat_callback | grep "$payment_hash" | grep -q "accountId" || exit 1
-  ! cat_callback | grep "$payment_hash" | grep -q "walletId" || exit 1
-  ! cat_callback | grep "$payment_hash" | grep -q "transaction" || exit 1
-  ! cat_callback | grep "$payment_hash" | grep -q "externalId" || exit 1
-  ! cat_callback | grep "$payment_hash" | grep -q "$btc_wallet_id" || exit 1
+@test "public-ln-receive: receive via usd invoice - sends terminal invoice webhook" {
+  token_name="$ALICE"
+  usd_wallet_name="$token_name.usd_wallet_id"
+  usd_wallet_id="$(read_value $usd_wallet_name)"
+
+  variables=$(
+    jq -n \
+    --arg wallet_id "$usd_wallet_id" \
+    --arg amount "$usd_amount" \
+    --arg webhook_url "$SVIX_CALLBACK_URL" \
+    '{input: {recipientWalletId: $wallet_id, amount: $amount, webhookUrl: $webhook_url}}'
+  )
+  exec_graphql 'anon' 'ln-usd-invoice-create-on-behalf-of-recipient' "$variables"
+  invoice="$(graphql_output '.data.lnUsdInvoiceCreateOnBehalfOfRecipient.invoice')"
+
+  payment_request="$(echo $invoice | jq -r '.paymentRequest')"
+  [[ "${payment_request}" != "null" ]] || exit 1
+
+  payment_hash="$(echo $invoice | jq -r '.paymentHash')"
+  [[ "${payment_hash}" != "null" ]] || exit 1
+
+  payment_result="$(lnd_outside_cli payinvoice -f --pay_req "$payment_request" --json)"
+  preimage="$(echo "$payment_result" | jq -r '.payment_preimage')"
+
+  retry 15 1 check_ln_payment_settled_by_hash "$payment_request" "$payment_hash"
+  assert_terminal_invoice_webhook \
+    "$payment_hash" \
+    "$payment_request" \
+    "$preimage" \
+    "$usd_wallet_id"
+}
+
+@test "public-ln-receive: receive via usd sats-denominated invoice - sends terminal invoice webhook" {
+  token_name="$ALICE"
+  usd_wallet_name="$token_name.usd_wallet_id"
+  usd_wallet_id="$(read_value $usd_wallet_name)"
+
+  variables=$(
+    jq -n \
+    --arg wallet_id "$usd_wallet_id" \
+    --arg amount "$btc_amount" \
+    --arg webhook_url "$SVIX_CALLBACK_URL" \
+    '{input: {recipientWalletId: $wallet_id, amount: $amount, webhookUrl: $webhook_url}}'
+  )
+  exec_graphql \
+    'anon' \
+    'ln-usd-invoice-btc-denominated-create-on-behalf-of-recipient' \
+    "$variables"
+  invoice="$(graphql_output '.data.lnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipient.invoice')"
+
+  payment_request="$(echo $invoice | jq -r '.paymentRequest')"
+  [[ "${payment_request}" != "null" ]] || exit 1
+
+  payment_hash="$(echo $invoice | jq -r '.paymentHash')"
+  [[ "${payment_hash}" != "null" ]] || exit 1
+
+  payment_result="$(lnd_outside_cli payinvoice -f --pay_req "$payment_request" --json)"
+  preimage="$(echo "$payment_result" | jq -r '.payment_preimage')"
+
+  retry 15 1 check_ln_payment_settled_by_hash "$payment_request" "$payment_hash"
+  assert_terminal_invoice_webhook \
+    "$payment_hash" \
+    "$payment_request" \
+    "$preimage" \
+    "$usd_wallet_id"
+}
+
+@test "public-ln-receive: receive via no amount invoice - sends terminal invoice webhook" {
+  token_name="$ALICE"
+  btc_wallet_name="$token_name.btc_wallet_id"
+  btc_wallet_id="$(read_value $btc_wallet_name)"
+
+  variables=$(
+    jq -n \
+    --arg wallet_id "$btc_wallet_id" \
+    --arg webhook_url "$SVIX_CALLBACK_URL" \
+    '{input: {recipientWalletId: $wallet_id, webhookUrl: $webhook_url}}'
+  )
+  exec_graphql 'anon' 'ln-no-amount-invoice-create-on-behalf-of-recipient' "$variables"
+  invoice="$(graphql_output '.data.lnNoAmountInvoiceCreateOnBehalfOfRecipient.invoice')"
+
+  payment_request="$(echo $invoice | jq -r '.paymentRequest')"
+  [[ "${payment_request}" != "null" ]] || exit 1
+
+  payment_hash="$(echo $invoice | jq -r '.paymentHash')"
+  [[ "${payment_hash}" != "null" ]] || exit 1
+
+  payment_result="$(lnd_outside_cli payinvoice -f --pay_req "$payment_request" --amt "$btc_amount" --json)"
+  preimage="$(echo "$payment_result" | jq -r '.payment_preimage')"
+
+  retry 15 1 check_ln_payment_settled_by_hash "$payment_request" "$payment_hash"
+  assert_terminal_invoice_webhook \
+    "$payment_hash" \
+    "$payment_request" \
+    "$preimage" \
+    "$btc_wallet_id"
 }
 
 @test "public-ln-receive: receive via invoice - can receive on usd invoice" {

--- a/bats/core/api/public-ln-receive.bats
+++ b/bats/core/api/public-ln-receive.bats
@@ -6,6 +6,7 @@ load "../../helpers/ledger.bash"
 load "../../helpers/ln.bash"
 load "../../helpers/subscriber.bash"
 load "../../helpers/user.bash"
+load "../../helpers/callback.bash"
 
 ALICE='alice'
 
@@ -287,6 +288,43 @@ usd_amount=50
   retry 10 1 grep "Data.*lnInvoicePaymentStatusByHash.*$payment_request" "$SUBSCRIBER_LOG_FILE"
   retry 10 1 grep "Data.*lnInvoicePaymentStatusByHash.*$preimage" "$SUBSCRIBER_LOG_FILE"
   stop_subscriber
+}
+
+@test "public-ln-receive: receive via invoice - sends terminal invoice webhook" {
+  token_name="$ALICE"
+  btc_wallet_name="$token_name.btc_wallet_id"
+  btc_wallet_id="$(read_value $btc_wallet_name)"
+
+  variables=$(
+    jq -n \
+    --arg wallet_id "$btc_wallet_id" \
+    --arg amount "$btc_amount" \
+    --arg webhook_url "$SVIX_CALLBACK_URL" \
+    '{input: {recipientWalletId: $wallet_id, amount: $amount, webhookUrl: $webhook_url}}'
+  )
+  exec_graphql 'anon' 'ln-invoice-create-on-behalf-of-recipient' "$variables"
+  invoice="$(graphql_output '.data.lnInvoiceCreateOnBehalfOfRecipient.invoice')"
+
+  payment_request="$(echo $invoice | jq -r '.paymentRequest')"
+  [[ "${payment_request}" != "null" ]] || exit 1
+
+  payment_hash="$(echo $invoice | jq -r '.paymentHash')"
+  [[ "${payment_hash}" != "null" ]] || exit 1
+
+  payment_result="$(lnd_outside_cli payinvoice -f --pay_req "$payment_request" --json)"
+  preimage="$(echo "$payment_result" | jq -r '.payment_preimage')"
+
+  retry 15 1 check_ln_payment_settled_by_hash "$payment_request" "$payment_hash"
+  retry 15 1 grep "callback │ .*$payment_hash" "$TILT_LOG_FILE"
+  retry 15 1 grep "callback │ .*$payment_request" "$TILT_LOG_FILE"
+  retry 15 1 grep "callback │ .*PAID" "$TILT_LOG_FILE"
+  retry 15 1 grep "callback │ .*$preimage" "$TILT_LOG_FILE"
+
+  ! cat_callback | grep "$payment_hash" | grep -q "accountId" || exit 1
+  ! cat_callback | grep "$payment_hash" | grep -q "walletId" || exit 1
+  ! cat_callback | grep "$payment_hash" | grep -q "transaction" || exit 1
+  ! cat_callback | grep "$payment_hash" | grep -q "externalId" || exit 1
+  ! cat_callback | grep "$payment_hash" | grep -q "$btc_wallet_id" || exit 1
 }
 
 @test "public-ln-receive: receive via invoice - can receive on usd invoice" {

--- a/bats/core/api/public-ln-receive.bats
+++ b/bats/core/api/public-ln-receive.bats
@@ -27,7 +27,7 @@ teardown() {
 btc_amount=1000
 usd_amount=50
 
-assert_terminal_invoice_webhook() {
+assert_invoice_webhook() {
   local payment_hash=$1
   local payment_request=$2
   local preimage=$3
@@ -308,7 +308,7 @@ assert_terminal_invoice_webhook() {
   stop_subscriber
 }
 
-@test "public-ln-receive: receive via invoice - sends terminal invoice webhook" {
+@test "public-ln-receive: receive via invoice - sends invoice webhook" {
   token_name="$ALICE"
   btc_wallet_name="$token_name.btc_wallet_id"
   btc_wallet_id="$(read_value $btc_wallet_name)"
@@ -333,14 +333,14 @@ assert_terminal_invoice_webhook() {
   preimage="$(echo "$payment_result" | jq -r '.payment_preimage')"
 
   retry 15 1 check_ln_payment_settled_by_hash "$payment_request" "$payment_hash"
-  assert_terminal_invoice_webhook \
+  assert_invoice_webhook \
     "$payment_hash" \
     "$payment_request" \
     "$preimage" \
     "$btc_wallet_id"
 }
 
-@test "public-ln-receive: receive via usd invoice - sends terminal invoice webhook" {
+@test "public-ln-receive: receive via usd invoice - sends invoice webhook" {
   token_name="$ALICE"
   usd_wallet_name="$token_name.usd_wallet_id"
   usd_wallet_id="$(read_value $usd_wallet_name)"
@@ -365,14 +365,14 @@ assert_terminal_invoice_webhook() {
   preimage="$(echo "$payment_result" | jq -r '.payment_preimage')"
 
   retry 15 1 check_ln_payment_settled_by_hash "$payment_request" "$payment_hash"
-  assert_terminal_invoice_webhook \
+  assert_invoice_webhook \
     "$payment_hash" \
     "$payment_request" \
     "$preimage" \
     "$usd_wallet_id"
 }
 
-@test "public-ln-receive: receive via usd sats-denominated invoice - sends terminal invoice webhook" {
+@test "public-ln-receive: receive via usd sats-denominated invoice - sends invoice webhook" {
   token_name="$ALICE"
   usd_wallet_name="$token_name.usd_wallet_id"
   usd_wallet_id="$(read_value $usd_wallet_name)"
@@ -400,14 +400,14 @@ assert_terminal_invoice_webhook() {
   preimage="$(echo "$payment_result" | jq -r '.payment_preimage')"
 
   retry 15 1 check_ln_payment_settled_by_hash "$payment_request" "$payment_hash"
-  assert_terminal_invoice_webhook \
+  assert_invoice_webhook \
     "$payment_hash" \
     "$payment_request" \
     "$preimage" \
     "$usd_wallet_id"
 }
 
-@test "public-ln-receive: receive via no amount invoice - sends terminal invoice webhook" {
+@test "public-ln-receive: receive via no amount invoice - sends invoice webhook" {
   token_name="$ALICE"
   btc_wallet_name="$token_name.btc_wallet_id"
   btc_wallet_id="$(read_value $btc_wallet_name)"
@@ -431,7 +431,7 @@ assert_terminal_invoice_webhook() {
   preimage="$(echo "$payment_result" | jq -r '.payment_preimage')"
 
   retry 15 1 check_ln_payment_settled_by_hash "$payment_request" "$payment_hash"
-  assert_terminal_invoice_webhook \
+  assert_invoice_webhook \
     "$payment_hash" \
     "$payment_request" \
     "$preimage" \

--- a/core/api/src/app/wallets/add-invoice-for-wallet.ts
+++ b/core/api/src/app/wallets/add-invoice-for-wallet.ts
@@ -21,6 +21,7 @@ import {
   WalletInvoicesRepository,
   WalletsRepository,
 } from "@/services/mongoose"
+import { recordExceptionInCurrentSpan } from "@/services/tracing"
 
 const defaultBtcExpiration = secondsToMinutes(INVOICE_EXPIRATIONS["BTC"].defaultValue)
 const defaultNoAmountBtcExpiration = secondsToMinutes(
@@ -375,22 +376,29 @@ const addInvoice = async ({
   const invoice = await walletIBWithAmount.registerInvoice()
   if (invoice instanceof Error) return invoice
 
+  const callbackService = CallbackService(getCallbackServiceConfig())
   if (webhookUrl) {
     invoice.webhookUrl = webhookUrl
     invoice.webhookStatus = WalletInvoiceWebhookStatus.Pending
-  }
 
-  const persistedInvoice = await WalletInvoicesRepository().persistNew(invoice)
-  if (persistedInvoice instanceof Error) return persistedInvoice
-
-  if (webhookUrl) {
-    const endpointId = await CallbackService(
-      getCallbackServiceConfig(),
-    ).addInvoiceEndpoint({
+    const endpointId = await callbackService.addInvoiceEndpoint({
       paymentHash: invoice.paymentHash,
       url: webhookUrl,
     })
     if (endpointId instanceof Error) return endpointId
+  }
+
+  const persistedInvoice = await WalletInvoicesRepository().persistNew(invoice)
+  if (persistedInvoice instanceof Error) {
+    if (webhookUrl) {
+      const deleted = await callbackService.deleteInvoiceApplication({
+        paymentHash: invoice.paymentHash,
+      })
+      if (deleted instanceof Error) {
+        recordExceptionInCurrentSpan({ error: deleted })
+      }
+    }
+    return persistedInvoice
   }
 
   return invoice

--- a/core/api/src/app/wallets/add-invoice-for-wallet.ts
+++ b/core/api/src/app/wallets/add-invoice-for-wallet.ts
@@ -1,5 +1,6 @@
 import { validateIsBtcWallet, validateIsUsdWallet } from "./validate"
 
+import { getCallbackServiceConfig } from "@/config"
 import { AccountValidator } from "@/domain/accounts"
 import { checkedToLedgerExternalId } from "@/domain/ledger"
 import { checkedToWalletId } from "@/domain/wallets"
@@ -8,11 +9,13 @@ import { checkedToMinutes, secondsToMinutes } from "@/domain/primitives"
 import { RateLimiterExceededError } from "@/domain/rate-limit/errors"
 import { INVOICE_EXPIRATIONS } from "@/domain/bitcoin/lightning/invoice-expiration"
 import { WalletInvoiceBuilder } from "@/domain/wallet-invoices/wallet-invoice-builder"
+import { WalletInvoiceWebhookStatus } from "@/domain/wallet-invoices"
 import { checkedToBtcPaymentAmount, checkedToUsdPaymentAmount } from "@/domain/shared"
 
 import { LndService } from "@/services/lnd"
 import { consumeLimiter } from "@/services/rate-limit"
 import { DealerPriceService } from "@/services/dealer-price"
+import { CallbackService } from "@/services/svix"
 import {
   AccountsRepository,
   WalletInvoicesRepository,
@@ -168,9 +171,11 @@ const addInvoiceForRecipient = async ({
   descriptionHash,
   expiresIn,
   externalId,
+  webhookUrl,
 }: AddInvoiceForRecipientArgs): Promise<WalletInvoice | ApplicationError> => {
   return addInvoice({
     walletId: recipientWalletId,
+    webhookUrl,
     limitCheckFn: checkRecipientWalletIdRateLimits,
     buildWIBWithAmountFn: ({
       walletInvoiceBuilder,
@@ -213,6 +218,7 @@ export const addInvoiceForRecipientForBtcWallet = async (
     descriptionHash: args.descriptionHash,
     memo: args.memo,
     externalId,
+    webhookUrl: args.webhookUrl,
   })
 }
 
@@ -243,6 +249,7 @@ export const addInvoiceForRecipientForUsdWallet = async (
     descriptionHash: args.descriptionHash,
     memo: args.memo,
     externalId,
+    webhookUrl: args.webhookUrl,
   })
 }
 
@@ -273,6 +280,7 @@ export const addInvoiceForRecipientForUsdWalletAndBtcAmount = async (
     descriptionHash: args.descriptionHash,
     memo: args.memo,
     externalId,
+    webhookUrl: args.webhookUrl,
   })
 }
 
@@ -281,9 +289,11 @@ const addInvoiceNoAmountForRecipient = async ({
   memo = "",
   expiresIn,
   externalId,
+  webhookUrl,
 }: AddInvoiceNoAmountForRecipientArgs): Promise<WalletInvoice | ApplicationError> => {
   return addInvoice({
     walletId: recipientWalletId,
+    webhookUrl,
     limitCheckFn: checkRecipientWalletIdRateLimits,
     buildWIBWithAmountFn: ({
       walletInvoiceBuilder,
@@ -324,11 +334,13 @@ export const addInvoiceNoAmountForRecipientForAnyWallet = async (
     expiresIn,
     memo: args.memo,
     externalId,
+    webhookUrl: args.webhookUrl,
   })
 }
 
 const addInvoice = async ({
   walletId,
+  webhookUrl,
   limitCheckFn,
   buildWIBWithAmountFn,
 }: AddInvoiceArgs): Promise<WalletInvoice | ApplicationError> => {
@@ -363,8 +375,21 @@ const addInvoice = async ({
   const invoice = await walletIBWithAmount.registerInvoice()
   if (invoice instanceof Error) return invoice
 
+  if (webhookUrl) {
+    invoice.webhookUrl = webhookUrl
+    invoice.webhookStatus = WalletInvoiceWebhookStatus.Pending
+  }
+
   const persistedInvoice = await WalletInvoicesRepository().persistNew(invoice)
   if (persistedInvoice instanceof Error) return persistedInvoice
+
+  if (webhookUrl) {
+    const endpointId = await CallbackService(getCallbackServiceConfig()).addInvoiceEndpoint({
+      paymentHash: invoice.paymentHash,
+      url: webhookUrl,
+    })
+    if (endpointId instanceof Error) return endpointId
+  }
 
   return invoice
 }

--- a/core/api/src/app/wallets/add-invoice-for-wallet.ts
+++ b/core/api/src/app/wallets/add-invoice-for-wallet.ts
@@ -384,7 +384,9 @@ const addInvoice = async ({
   if (persistedInvoice instanceof Error) return persistedInvoice
 
   if (webhookUrl) {
-    const endpointId = await CallbackService(getCallbackServiceConfig()).addInvoiceEndpoint({
+    const endpointId = await CallbackService(
+      getCallbackServiceConfig(),
+    ).addInvoiceEndpoint({
       paymentHash: invoice.paymentHash,
       url: webhookUrl,
     })

--- a/core/api/src/app/wallets/cancel-invoice-for-wallet.ts
+++ b/core/api/src/app/wallets/cancel-invoice-for-wallet.ts
@@ -1,4 +1,4 @@
-import { sendTerminalInvoiceWebhook } from "./invoice-webhooks"
+import { sendInvoiceWebhook } from "./send-invoice-webhook"
 
 import { InvoiceAlreadyProcessedError } from "@/domain/wallet-invoices/errors"
 import { AccountValidator } from "@/domain/accounts"
@@ -62,7 +62,7 @@ export const cancelInvoiceForWallet = async ({
     const updatedInvoice = await walletInvoices.markAsProcessingCompleted(paymentHash)
     if (updatedInvoice instanceof Error) return result
 
-    sendTerminalInvoiceWebhook({ walletInvoice: updatedInvoice })
+    sendInvoiceWebhook({ walletInvoice: updatedInvoice })
 
     return true
   })

--- a/core/api/src/app/wallets/cancel-invoice-for-wallet.ts
+++ b/core/api/src/app/wallets/cancel-invoice-for-wallet.ts
@@ -1,3 +1,5 @@
+import { sendTerminalInvoiceWebhook } from "./invoice-webhooks"
+
 import { InvoiceAlreadyProcessedError } from "@/domain/wallet-invoices/errors"
 import { AccountValidator } from "@/domain/accounts"
 import { checkedToWalletId } from "@/domain/wallets"
@@ -59,6 +61,8 @@ export const cancelInvoiceForWallet = async ({
 
     const updatedInvoice = await walletInvoices.markAsProcessingCompleted(paymentHash)
     if (updatedInvoice instanceof Error) return result
+
+    sendTerminalInvoiceWebhook({ walletInvoice: updatedInvoice })
 
     return true
   })

--- a/core/api/src/app/wallets/index.ts
+++ b/core/api/src/app/wallets/index.ts
@@ -23,6 +23,7 @@ export * from "./get-invoice-for-wallet-by-hash"
 export * from "./get-pending-incoming-on-chain-transactions-for-wallets"
 export * from "./get-pending-incoming-on-chain-transactions-by-addresses"
 export * from "./get-invoices-for-wallets"
+export * from "./invoice-webhooks"
 
 import { WalletsRepository } from "@/services/mongoose"
 

--- a/core/api/src/app/wallets/index.ts
+++ b/core/api/src/app/wallets/index.ts
@@ -23,7 +23,7 @@ export * from "./get-invoice-for-wallet-by-hash"
 export * from "./get-pending-incoming-on-chain-transactions-for-wallets"
 export * from "./get-pending-incoming-on-chain-transactions-by-addresses"
 export * from "./get-invoices-for-wallets"
-export * from "./invoice-webhooks"
+export * from "./send-invoice-webhook"
 
 import { WalletsRepository } from "@/services/mongoose"
 

--- a/core/api/src/app/wallets/index.types.d.ts
+++ b/core/api/src/app/wallets/index.types.d.ts
@@ -37,6 +37,7 @@ type AddInvoiceForRecipientArgs = {
   descriptionHash?: string
   expiresIn: Minutes
   externalId: LedgerExternalId | undefined
+  webhookUrl?: string
 }
 
 type AddInvoiceForRecipientForBtcWalletArgs = {
@@ -46,6 +47,7 @@ type AddInvoiceForRecipientForBtcWalletArgs = {
   descriptionHash?: string
   expiresIn?: number
   externalId: string | undefined
+  webhookUrl?: string
 }
 
 type AddInvoiceForRecipientForUsdWalletArgs = AddInvoiceForRecipientForBtcWalletArgs
@@ -55,6 +57,7 @@ type AddInvoiceNoAmountForRecipientArgs = {
   memo?: string
   expiresIn: Minutes
   externalId: LedgerExternalId | undefined
+  webhookUrl?: string
 }
 
 type AddInvoiceNoAmountForRecipientForAnyWalletArgs = {
@@ -62,6 +65,7 @@ type AddInvoiceNoAmountForRecipientForAnyWalletArgs = {
   memo?: string
   expiresIn?: number
   externalId: string | undefined
+  webhookUrl?: string
 }
 
 type CancelInvoiceForWalletArgs = {
@@ -76,6 +80,7 @@ type BuildWIBWithAmountFnArgs = {
 
 type AddInvoiceArgs = {
   walletId: WalletId
+  webhookUrl?: string
   limitCheckFn: (accountId: AccountId) => Promise<true | RateLimitServiceError>
   buildWIBWithAmountFn: (
     buildWIBWithAmountFnArgs: BuildWIBWithAmountFnArgs,

--- a/core/api/src/app/wallets/invoice-webhooks.ts
+++ b/core/api/src/app/wallets/invoice-webhooks.ts
@@ -1,0 +1,102 @@
+import { getCallbackServiceConfig } from "@/config"
+import { PaymentStatusCheckerByHash } from "@/app/lightning/payment-status-checker"
+import {
+  WalletInvoiceStatus,
+  WalletInvoiceWebhookStatus,
+} from "@/domain/wallet-invoices"
+import { WalletInvoicesRepository } from "@/services/mongoose"
+import { CallbackService } from "@/services/svix"
+import { baseLogger } from "@/services/logger"
+
+const invoiceWebhookEventType = (status: WalletInvoiceStatus) =>
+  `invoice.${status.toLowerCase()}`
+
+const invoiceWebhookStatus = (status: WalletInvoiceStatus) => status.toUpperCase()
+
+const terminalInvoiceWebhookPayload = async (paymentHash: PaymentHash) => {
+  const paymentStatusChecker = await PaymentStatusCheckerByHash({ paymentHash })
+  if (paymentStatusChecker instanceof Error) return paymentStatusChecker
+
+  const paid = await paymentStatusChecker.invoiceIsPaid()
+  if (paid instanceof Error) return paid
+
+  const { paymentRequest, isExpired } = paymentStatusChecker
+
+  if (paid) {
+    const paymentPreimage = await paymentStatusChecker.getPreImage()
+    if (paymentPreimage instanceof Error) return paymentPreimage
+
+    return {
+      paymentHash,
+      paymentRequest,
+      status: invoiceWebhookStatus(WalletInvoiceStatus.Paid),
+      paymentPreimage,
+    }
+  }
+
+  if (!isExpired) return undefined
+
+  return {
+    paymentHash,
+    paymentRequest,
+    status: invoiceWebhookStatus(WalletInvoiceStatus.Expired),
+  }
+}
+
+export const sendTerminalInvoiceWebhook = async ({
+  walletInvoice,
+  logger = baseLogger,
+}: {
+  walletInvoice: WalletInvoiceWithOptionalLnInvoice
+  logger?: Logger
+}): Promise<true | ApplicationError> => {
+  const { paymentHash, webhookStatus, webhookUrl } = walletInvoice
+  if (!webhookUrl || webhookStatus !== WalletInvoiceWebhookStatus.Pending) return true
+
+  const payload = await terminalInvoiceWebhookPayload(paymentHash)
+  if (payload instanceof Error) return payload
+  if (!payload) return true
+
+  const callbackService = CallbackService(getCallbackServiceConfig())
+  const sent = await callbackService.sendInvoiceMessage({
+    paymentHash,
+    eventType: invoiceWebhookEventType(
+      payload.status === invoiceWebhookStatus(WalletInvoiceStatus.Paid)
+        ? WalletInvoiceStatus.Paid
+        : WalletInvoiceStatus.Expired,
+    ),
+    payload,
+  })
+  if (sent instanceof Error) return sent
+
+  const marked = await WalletInvoicesRepository().markWebhookFinalSent(paymentHash)
+  if (marked instanceof Error) return marked
+
+  const deleted = await callbackService.deleteInvoiceApplication(paymentHash)
+  if (deleted instanceof Error) {
+    logger.warn({ err: deleted, paymentHash }, "Unable to delete invoice webhook app")
+  }
+
+  return true
+}
+
+export const sendPendingTerminalInvoiceWebhooks = async ({
+  logger = baseLogger,
+}: {
+  logger?: Logger
+} = {}): Promise<true | ApplicationError> => {
+  const pendingWebhooks = WalletInvoicesRepository().yieldPendingWebhooks()
+  if (pendingWebhooks instanceof Error) return pendingWebhooks
+
+  for await (const walletInvoice of pendingWebhooks) {
+    const result = await sendTerminalInvoiceWebhook({ walletInvoice, logger })
+    if (result instanceof Error) {
+      logger.error(
+        { err: result, paymentHash: walletInvoice.paymentHash },
+        "Unable to send terminal invoice webhook",
+      )
+    }
+  }
+
+  return true
+}

--- a/core/api/src/app/wallets/send-invoice-webhook.ts
+++ b/core/api/src/app/wallets/send-invoice-webhook.ts
@@ -67,7 +67,7 @@ export const sendInvoiceWebhook = async ({
   const marked = await WalletInvoicesRepository().markWebhookAsSent(paymentHash)
   if (marked instanceof Error) return marked
 
-  const deleted = await callbackService.deleteInvoiceApplication(paymentHash)
+  const deleted = await callbackService.deleteInvoiceApplication({ paymentHash })
   if (deleted instanceof Error) {
     recordExceptionInCurrentSpan({ error: deleted })
   }

--- a/core/api/src/app/wallets/send-invoice-webhook.ts
+++ b/core/api/src/app/wallets/send-invoice-webhook.ts
@@ -1,19 +1,16 @@
 import { getCallbackServiceConfig } from "@/config"
 import { PaymentStatusCheckerByHash } from "@/app/lightning/payment-status-checker"
-import {
-  WalletInvoiceStatus,
-  WalletInvoiceWebhookStatus,
-} from "@/domain/wallet-invoices"
+import { WalletInvoiceStatus, WalletInvoiceWebhookStatus } from "@/domain/wallet-invoices"
 import { WalletInvoicesRepository } from "@/services/mongoose"
 import { CallbackService } from "@/services/svix"
-import { baseLogger } from "@/services/logger"
+import { recordExceptionInCurrentSpan } from "@/services/tracing"
 
 const invoiceWebhookEventType = (status: WalletInvoiceStatus) =>
   `invoice.${status.toLowerCase()}`
 
 const invoiceWebhookStatus = (status: WalletInvoiceStatus) => status.toUpperCase()
 
-const terminalInvoiceWebhookPayload = async (paymentHash: PaymentHash) => {
+const buildInvoiceWebhookPayload = async (paymentHash: PaymentHash) => {
   const paymentStatusChecker = await PaymentStatusCheckerByHash({ paymentHash })
   if (paymentStatusChecker instanceof Error) return paymentStatusChecker
 
@@ -43,17 +40,15 @@ const terminalInvoiceWebhookPayload = async (paymentHash: PaymentHash) => {
   }
 }
 
-export const sendTerminalInvoiceWebhook = async ({
+export const sendInvoiceWebhook = async ({
   walletInvoice,
-  logger = baseLogger,
 }: {
   walletInvoice: WalletInvoiceWithOptionalLnInvoice
-  logger?: Logger
 }): Promise<true | ApplicationError> => {
   const { paymentHash, webhookStatus, webhookUrl } = walletInvoice
   if (!webhookUrl || webhookStatus !== WalletInvoiceWebhookStatus.Pending) return true
 
-  const payload = await terminalInvoiceWebhookPayload(paymentHash)
+  const payload = await buildInvoiceWebhookPayload(paymentHash)
   if (payload instanceof Error) return payload
   if (!payload) return true
 
@@ -69,32 +64,25 @@ export const sendTerminalInvoiceWebhook = async ({
   })
   if (sent instanceof Error) return sent
 
-  const marked = await WalletInvoicesRepository().markWebhookFinalSent(paymentHash)
+  const marked = await WalletInvoicesRepository().markWebhookAsSent(paymentHash)
   if (marked instanceof Error) return marked
 
   const deleted = await callbackService.deleteInvoiceApplication(paymentHash)
   if (deleted instanceof Error) {
-    logger.warn({ err: deleted, paymentHash }, "Unable to delete invoice webhook app")
+    recordExceptionInCurrentSpan({ error: deleted })
   }
 
   return true
 }
 
-export const sendPendingTerminalInvoiceWebhooks = async ({
-  logger = baseLogger,
-}: {
-  logger?: Logger
-} = {}): Promise<true | ApplicationError> => {
+export const sendPendingInvoiceWebhooks = async (): Promise<true | ApplicationError> => {
   const pendingWebhooks = WalletInvoicesRepository().yieldPendingWebhooks()
   if (pendingWebhooks instanceof Error) return pendingWebhooks
 
   for await (const walletInvoice of pendingWebhooks) {
-    const result = await sendTerminalInvoiceWebhook({ walletInvoice, logger })
+    const result = await sendInvoiceWebhook({ walletInvoice })
     if (result instanceof Error) {
-      logger.error(
-        { err: result, paymentHash: walletInvoice.paymentHash },
-        "Unable to send terminal invoice webhook",
-      )
+      recordExceptionInCurrentSpan({ error: result })
     }
   }
 

--- a/core/api/src/app/wallets/update-single-pending-invoice.ts
+++ b/core/api/src/app/wallets/update-single-pending-invoice.ts
@@ -1,5 +1,5 @@
 import { getTransactionForWalletByJournalId } from "./get-transaction-by-journal-id"
-import { sendTerminalInvoiceWebhook } from "./invoice-webhooks"
+import { sendInvoiceWebhook } from "./send-invoice-webhook"
 
 import { processPendingInvoiceForDecline } from "./decline-single-pending-invoice"
 
@@ -81,9 +81,8 @@ export const updatePendingInvoice = wrapAsyncToRunInSpan({
           pendingInvoiceLogger.error("Unable to mark invoice as processingCompleted")
           return marked
         }
-        sendTerminalInvoiceWebhook({
+        sendInvoiceWebhook({
           walletInvoice: marked,
-          logger: pendingInvoiceLogger,
         })
         return true
 
@@ -97,9 +96,8 @@ export const updatePendingInvoice = wrapAsyncToRunInSpan({
           return marked
         }
         if (!(marked instanceof Error)) {
-          sendTerminalInvoiceWebhook({
+          sendInvoiceWebhook({
             walletInvoice: marked,
-            logger: pendingInvoiceLogger,
           })
         }
         return "error" in result ? result.error : true

--- a/core/api/src/app/wallets/update-single-pending-invoice.ts
+++ b/core/api/src/app/wallets/update-single-pending-invoice.ts
@@ -1,4 +1,5 @@
 import { getTransactionForWalletByJournalId } from "./get-transaction-by-journal-id"
+import { sendTerminalInvoiceWebhook } from "./invoice-webhooks"
 
 import { processPendingInvoiceForDecline } from "./decline-single-pending-invoice"
 
@@ -80,6 +81,10 @@ export const updatePendingInvoice = wrapAsyncToRunInSpan({
           pendingInvoiceLogger.error("Unable to mark invoice as processingCompleted")
           return marked
         }
+        sendTerminalInvoiceWebhook({
+          walletInvoice: marked,
+          logger: pendingInvoiceLogger,
+        })
         return true
 
       case ProcessPendingInvoiceResultType.MarkProcessedAsPaid:
@@ -90,6 +95,12 @@ export const updatePendingInvoice = wrapAsyncToRunInSpan({
           !(marked instanceof CouldNotFindWalletInvoiceError)
         ) {
           return marked
+        }
+        if (!(marked instanceof Error)) {
+          sendTerminalInvoiceWebhook({
+            walletInvoice: marked,
+            logger: pendingInvoiceLogger,
+          })
         }
         return "error" in result ? result.error : true
 

--- a/core/api/src/domain/callback/index.types.d.ts
+++ b/core/api/src/domain/callback/index.types.d.ts
@@ -4,6 +4,7 @@ type CallbackEventType =
   (typeof import("./index").CallbackEventType)[keyof typeof import("./index").CallbackEventType]
 
 type AccountCallbackId = string & { readonly brand: unique symbol }
+type InvoiceCallbackId = string & { readonly brand: unique symbol }
 
 interface ICallbackService {
   sendMessage: (args: {
@@ -24,4 +25,19 @@ interface ICallbackService {
     accountId: AccountId
     endpointId: string
   }) => Promise<CallbackServiceError | true>
+
+  addInvoiceEndpoint: (args: {
+    paymentHash: PaymentHash
+    url: string
+  }) => Promise<CallbackServiceError | string>
+
+  sendInvoiceMessage: (args: {
+    paymentHash: PaymentHash
+    eventType: string
+    payload: Record<string, JSONValue>
+  }) => Promise<CallbackServiceError | true>
+
+  deleteInvoiceApplication: (
+    paymentHash: PaymentHash,
+  ) => Promise<CallbackServiceError | true>
 }

--- a/core/api/src/domain/callback/index.types.d.ts
+++ b/core/api/src/domain/callback/index.types.d.ts
@@ -37,7 +37,7 @@ interface ICallbackService {
     payload: Record<string, JSONValue>
   }) => Promise<CallbackServiceError | true>
 
-  deleteInvoiceApplication: (
-    paymentHash: PaymentHash,
-  ) => Promise<CallbackServiceError | true>
+  deleteInvoiceApplication: (args: {
+    paymentHash: PaymentHash
+  }) => Promise<CallbackServiceError | true>
 }

--- a/core/api/src/domain/wallet-invoices/index.ts
+++ b/core/api/src/domain/wallet-invoices/index.ts
@@ -5,3 +5,8 @@ export const WalletInvoiceStatus = {
   Paid: "Paid",
   Expired: "Expired",
 } as const
+
+export const WalletInvoiceWebhookStatus = {
+  Pending: "pending",
+  FinalSent: "final_sent",
+} as const

--- a/core/api/src/domain/wallet-invoices/index.ts
+++ b/core/api/src/domain/wallet-invoices/index.ts
@@ -8,5 +8,5 @@ export const WalletInvoiceStatus = {
 
 export const WalletInvoiceWebhookStatus = {
   Pending: "pending",
-  FinalSent: "final_sent",
+  Sent: "sent",
 } as const

--- a/core/api/src/domain/wallet-invoices/index.types.d.ts
+++ b/core/api/src/domain/wallet-invoices/index.types.d.ts
@@ -213,7 +213,7 @@ interface IWalletInvoicesRepository {
     paymentHash: PaymentHash,
   ) => Promise<WalletInvoiceWithOptionalLnInvoice | RepositoryError>
 
-  markWebhookFinalSent: (
+  markWebhookAsSent: (
     paymentHash: PaymentHash,
   ) => Promise<WalletInvoiceWithOptionalLnInvoice | RepositoryError>
 

--- a/core/api/src/domain/wallet-invoices/index.types.d.ts
+++ b/core/api/src/domain/wallet-invoices/index.types.d.ts
@@ -13,6 +13,9 @@ type WalletInvoiceChecker = {
 type WalletInvoiceStatus =
   (typeof import("./index").WalletInvoiceStatus)[keyof typeof import("./index").WalletInvoiceStatus]
 
+type WalletInvoiceWebhookStatus =
+  (typeof import("./index").WalletInvoiceWebhookStatus)[keyof typeof import("./index").WalletInvoiceWebhookStatus]
+
 type WalletInvoiceStatusChecker = {
   status: (currentTime: Date) => WalletInvoiceStatus
 }
@@ -103,6 +106,8 @@ type WalletInvoiceWithOptionalLnInvoice = {
   createdAt: Date
   processingCompleted: boolean
   externalId: LedgerExternalId
+  webhookUrl?: string
+  webhookStatus?: WalletInvoiceWebhookStatus
   lnInvoice?: LnInvoice // LnInvoice is optional because some older invoices don't have it
 }
 
@@ -207,4 +212,12 @@ interface IWalletInvoicesRepository {
   markAsProcessingCompleted: (
     paymentHash: PaymentHash,
   ) => Promise<WalletInvoiceWithOptionalLnInvoice | RepositoryError>
+
+  markWebhookFinalSent: (
+    paymentHash: PaymentHash,
+  ) => Promise<WalletInvoiceWithOptionalLnInvoice | RepositoryError>
+
+  yieldPendingWebhooks: () =>
+    | AsyncGenerator<WalletInvoiceWithOptionalLnInvoice>
+    | RepositoryError
 }

--- a/core/api/src/graphql/public/root/mutation/ln-invoice-create-on-behalf-of-recipient.ts
+++ b/core/api/src/graphql/public/root/mutation/ln-invoice-create-on-behalf-of-recipient.ts
@@ -11,6 +11,7 @@ import Hex32Bytes from "@/graphql/public/types/scalar/hex32bytes"
 import TxExternalId from "@/graphql/shared/types/scalar/tx-external-id"
 import LnInvoicePayload from "@/graphql/public/types/payload/ln-invoice"
 import { mapAndParseErrorForGqlResponse } from "@/graphql/error-map"
+import EndpointUrl from "@/graphql/public/types/scalar/endpoint-url"
 
 const LnInvoiceCreateOnBehalfOfRecipientInput = GT.Input({
   name: "LnInvoiceCreateOnBehalfOfRecipientInput",
@@ -27,6 +28,7 @@ const LnInvoiceCreateOnBehalfOfRecipientInput = GT.Input({
       description: "Optional invoice expiration time in minutes.",
     },
     externalId: { type: TxExternalId },
+    webhookUrl: { type: EndpointUrl },
   }),
 })
 
@@ -42,8 +44,15 @@ const LnInvoiceCreateOnBehalfOfRecipientMutation = GT.Field({
     input: { type: GT.NonNull(LnInvoiceCreateOnBehalfOfRecipientInput) },
   },
   resolve: async (_, args) => {
-    const { recipientWalletId, amount, memo, descriptionHash, expiresIn, externalId } =
-      args.input
+    const {
+      recipientWalletId,
+      amount,
+      memo,
+      descriptionHash,
+      expiresIn,
+      externalId,
+      webhookUrl,
+    } = args.input
     for (const input of [
       recipientWalletId,
       amount,
@@ -51,6 +60,7 @@ const LnInvoiceCreateOnBehalfOfRecipientMutation = GT.Field({
       descriptionHash,
       expiresIn,
       externalId,
+      webhookUrl,
     ]) {
       if (input instanceof Error) {
         return { errors: [{ message: input.message }] }
@@ -64,6 +74,7 @@ const LnInvoiceCreateOnBehalfOfRecipientMutation = GT.Field({
       descriptionHash,
       expiresIn,
       externalId,
+      webhookUrl,
     })
 
     if (invoice instanceof Error) {

--- a/core/api/src/graphql/public/root/mutation/ln-noamount-invoice-create-on-behalf-of-recipient.ts
+++ b/core/api/src/graphql/public/root/mutation/ln-noamount-invoice-create-on-behalf-of-recipient.ts
@@ -9,6 +9,7 @@ import TxExternalId from "@/graphql/shared/types/scalar/tx-external-id"
 import WalletId from "@/graphql/shared/types/scalar/wallet-id"
 import { mapAndParseErrorForGqlResponse } from "@/graphql/error-map"
 import LnNoAmountInvoicePayload from "@/graphql/public/types/payload/ln-noamount-invoice"
+import EndpointUrl from "@/graphql/public/types/scalar/endpoint-url"
 
 const LnNoAmountInvoiceCreateOnBehalfOfRecipientInput = GT.Input({
   name: "LnNoAmountInvoiceCreateOnBehalfOfRecipientInput",
@@ -24,6 +25,7 @@ const LnNoAmountInvoiceCreateOnBehalfOfRecipientInput = GT.Input({
       description: "Optional invoice expiration time in minutes.",
     },
     externalId: { type: TxExternalId },
+    webhookUrl: { type: EndpointUrl },
   }),
 })
 
@@ -39,9 +41,9 @@ const LnNoAmountInvoiceCreateOnBehalfOfRecipientMutation = GT.Field({
     input: { type: GT.NonNull(LnNoAmountInvoiceCreateOnBehalfOfRecipientInput) },
   },
   resolve: async (_, args) => {
-    const { recipientWalletId, memo, expiresIn, externalId } = args.input
+    const { recipientWalletId, memo, expiresIn, externalId, webhookUrl } = args.input
 
-    for (const input of [recipientWalletId, memo, expiresIn, externalId]) {
+    for (const input of [recipientWalletId, memo, expiresIn, externalId, webhookUrl]) {
       if (input instanceof Error) {
         return { errors: [{ message: input.message }] }
       }
@@ -52,6 +54,7 @@ const LnNoAmountInvoiceCreateOnBehalfOfRecipientMutation = GT.Field({
       memo,
       expiresIn,
       externalId,
+      webhookUrl,
     })
 
     if (invoice instanceof Error) {

--- a/core/api/src/graphql/public/root/mutation/ln-usd-invoice-btc-denominated-create-on-behalf-of-recipient.ts
+++ b/core/api/src/graphql/public/root/mutation/ln-usd-invoice-btc-denominated-create-on-behalf-of-recipient.ts
@@ -11,6 +11,7 @@ import SatAmount from "@/graphql/shared/types/scalar/sat-amount"
 import LnInvoicePayload from "@/graphql/public/types/payload/ln-invoice"
 import { mapAndParseErrorForGqlResponse } from "@/graphql/error-map"
 import TxExternalId from "@/graphql/shared/types/scalar/tx-external-id"
+import EndpointUrl from "@/graphql/public/types/scalar/endpoint-url"
 
 const LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientInput = GT.Input({
   name: "LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientInput",
@@ -31,6 +32,7 @@ const LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientInput = GT.Input({
       description: "Optional invoice expiration time in minutes.",
     },
     externalId: { type: TxExternalId },
+    webhookUrl: { type: EndpointUrl },
   }),
 })
 
@@ -49,8 +51,15 @@ const LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientMutation = GT.Field({
     },
   },
   resolve: async (_, args) => {
-    const { recipientWalletId, amount, memo, descriptionHash, expiresIn, externalId } =
-      args.input
+    const {
+      recipientWalletId,
+      amount,
+      memo,
+      descriptionHash,
+      expiresIn,
+      externalId,
+      webhookUrl,
+    } = args.input
     for (const input of [
       recipientWalletId,
       amount,
@@ -58,6 +67,7 @@ const LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientMutation = GT.Field({
       descriptionHash,
       expiresIn,
       externalId,
+      webhookUrl,
     ]) {
       if (input instanceof Error) {
         return { errors: [{ message: input.message }] }
@@ -71,6 +81,7 @@ const LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientMutation = GT.Field({
       descriptionHash,
       expiresIn,
       externalId,
+      webhookUrl,
     })
 
     if (invoice instanceof Error) {

--- a/core/api/src/graphql/public/root/mutation/ln-usd-invoice-create-on-behalf-of-recipient.ts
+++ b/core/api/src/graphql/public/root/mutation/ln-usd-invoice-create-on-behalf-of-recipient.ts
@@ -11,6 +11,7 @@ import CentAmount from "@/graphql/public/types/scalar/cent-amount"
 import TxExternalId from "@/graphql/shared/types/scalar/tx-external-id"
 import LnInvoicePayload from "@/graphql/public/types/payload/ln-invoice"
 import { mapAndParseErrorForGqlResponse } from "@/graphql/error-map"
+import EndpointUrl from "@/graphql/public/types/scalar/endpoint-url"
 
 const LnUsdInvoiceCreateOnBehalfOfRecipientInput = GT.Input({
   name: "LnUsdInvoiceCreateOnBehalfOfRecipientInput",
@@ -31,6 +32,7 @@ const LnUsdInvoiceCreateOnBehalfOfRecipientInput = GT.Input({
       description: "Optional invoice expiration time in minutes.",
     },
     externalId: { type: TxExternalId },
+    webhookUrl: { type: EndpointUrl },
   }),
 })
 
@@ -47,8 +49,15 @@ const LnUsdInvoiceCreateOnBehalfOfRecipientMutation = GT.Field({
     input: { type: GT.NonNull(LnUsdInvoiceCreateOnBehalfOfRecipientInput) },
   },
   resolve: async (_, args) => {
-    const { recipientWalletId, amount, memo, descriptionHash, expiresIn, externalId } =
-      args.input
+    const {
+      recipientWalletId,
+      amount,
+      memo,
+      descriptionHash,
+      expiresIn,
+      externalId,
+      webhookUrl,
+    } = args.input
     for (const input of [
       recipientWalletId,
       amount,
@@ -56,6 +65,7 @@ const LnUsdInvoiceCreateOnBehalfOfRecipientMutation = GT.Field({
       descriptionHash,
       expiresIn,
       externalId,
+      webhookUrl,
     ]) {
       if (input instanceof Error) {
         return { errors: [{ message: input.message }] }
@@ -69,6 +79,7 @@ const LnUsdInvoiceCreateOnBehalfOfRecipientMutation = GT.Field({
       descriptionHash,
       expiresIn,
       externalId,
+      webhookUrl,
     })
 
     if (invoice instanceof Error) {

--- a/core/api/src/graphql/public/schema.graphql
+++ b/core/api/src/graphql/public/schema.graphql
@@ -659,6 +659,7 @@ input LnInvoiceCreateOnBehalfOfRecipientInput {
 
   """Wallet ID for a BTC wallet which belongs to any account."""
   recipientWalletId: WalletId!
+  webhookUrl: EndpointUrl
 }
 
 input LnInvoiceFeeProbeInput {
@@ -746,6 +747,7 @@ input LnNoAmountInvoiceCreateOnBehalfOfRecipientInput {
   ID for either a USD or BTC wallet which belongs to the account of any user.
   """
   recipientWalletId: WalletId!
+  webhookUrl: EndpointUrl
 }
 
 input LnNoAmountInvoiceFeeProbeInput {
@@ -827,6 +829,7 @@ input LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientInput {
 
   """Wallet ID for a USD wallet which belongs to the account of any user."""
   recipientWalletId: WalletId!
+  webhookUrl: EndpointUrl
 }
 
 input LnUsdInvoiceCreateInput {
@@ -860,6 +863,7 @@ input LnUsdInvoiceCreateOnBehalfOfRecipientInput {
 
   """Wallet ID for a USD wallet which belongs to the account of any user."""
   recipientWalletId: WalletId!
+  webhookUrl: EndpointUrl
 }
 
 input LnUsdInvoiceFeeProbeInput {

--- a/core/api/src/servers/trigger.ts
+++ b/core/api/src/servers/trigger.ts
@@ -183,6 +183,12 @@ const watchHeldInvoices = () => {
   }, MS_PER_5_MINS)
 }
 
+const watchInvoiceWebhooks = () => {
+  return setInterval(async () => {
+    await Wallets.sendPendingTerminalInvoiceWebhooks({ logger })
+  }, MS_PER_5_MINS)
+}
+
 const listenerOnchain = (lnd: AuthenticatedLnd) => {
   const subTransactions = subscribeToTransactions({ lnd })
   const onChainTxHandler = wrapAsyncToRunInSpan({
@@ -456,6 +462,7 @@ const main = () => {
   activateLndHealthCheck()
   publishCurrentPrice()
   watchHeldInvoices()
+  watchInvoiceWebhooks()
 
   console.log("trigger server ready")
 }

--- a/core/api/src/servers/trigger.ts
+++ b/core/api/src/servers/trigger.ts
@@ -185,7 +185,7 @@ const watchHeldInvoices = () => {
 
 const watchInvoiceWebhooks = () => {
   return setInterval(async () => {
-    await Wallets.sendPendingTerminalInvoiceWebhooks({ logger })
+    await Wallets.sendPendingInvoiceWebhooks()
   }, MS_PER_5_MINS)
 }
 

--- a/core/api/src/services/mongoose/schema.ts
+++ b/core/api/src/services/mongoose/schema.ts
@@ -6,6 +6,7 @@ import { getDefaultAccountsConfig, Levels } from "@/config"
 import { AccountIdRegex, AccountStatus, UsernameRegex } from "@/domain/accounts"
 import { WalletIdRegex, WalletType } from "@/domain/wallets"
 import { WalletCurrency } from "@/domain/shared"
+import { WalletInvoiceWebhookStatus } from "@/domain/wallet-invoices"
 
 import { Languages } from "@/domain/users"
 import { ContactType } from "@/domain/contacts"
@@ -103,11 +104,21 @@ const walletInvoiceSchema = new Schema<WalletInvoiceRecord>({
     type: String,
     validator: (v: string) => !(checkedToLedgerExternalId(v) instanceof Error),
   },
+
+  webhookUrl: {
+    type: String,
+  },
+
+  webhookStatus: {
+    type: String,
+    enum: Object.values(WalletInvoiceWebhookStatus),
+  },
 })
 
 walletInvoiceSchema.index({ walletId: 1, paid: 1 })
 walletInvoiceSchema.index({ paid: 1, processingCompleted: 1 })
 walletInvoiceSchema.index({ accountId: 1, externalId: 1 }, { unique: true })
+walletInvoiceSchema.index({ webhookStatus: 1 })
 
 export const WalletInvoice = mongoose.model<WalletInvoiceRecord>(
   "InvoiceUser",

--- a/core/api/src/services/mongoose/schema.types.d.ts
+++ b/core/api/src/services/mongoose/schema.types.d.ts
@@ -73,6 +73,8 @@ interface WalletInvoiceRecord {
   paid: boolean
   paymentRequest?: string // optional because we historically did not store it
   externalId: string
+  webhookUrl?: string
+  webhookStatus?: string
 }
 
 interface AccountRecord {

--- a/core/api/src/services/mongoose/wallet-invoices.ts
+++ b/core/api/src/services/mongoose/wallet-invoices.ts
@@ -205,13 +205,13 @@ export const WalletInvoicesRepository = (): IWalletInvoicesRepository => {
     }
   }
 
-  const markWebhookFinalSent = async (
+  const markWebhookAsSent = async (
     paymentHash: PaymentHash,
   ): Promise<WalletInvoiceWithOptionalLnInvoice | RepositoryError> => {
     try {
       const walletInvoice = await WalletInvoice.findOneAndUpdate(
         { _id: paymentHash },
-        { webhookStatus: WalletInvoiceWebhookStatus.FinalSent },
+        { webhookStatus: WalletInvoiceWebhookStatus.Sent },
         { new: true },
       )
       if (!walletInvoice) {
@@ -319,7 +319,7 @@ export const WalletInvoicesRepository = (): IWalletInvoicesRepository => {
     persistNew,
     markAsPaid,
     markAsProcessingCompleted,
-    markWebhookFinalSent,
+    markWebhookAsSent,
     findByPaymentHash,
     findForWalletByPaymentHash,
     yieldPending,

--- a/core/api/src/services/mongoose/wallet-invoices.ts
+++ b/core/api/src/services/mongoose/wallet-invoices.ts
@@ -3,6 +3,7 @@ import { WalletInvoice } from "./schema"
 import { parseRepositoryError } from "./utils"
 
 import { decodeInvoice } from "@/domain/bitcoin/lightning"
+import { WalletInvoiceWebhookStatus } from "@/domain/wallet-invoices"
 
 import {
   CouldNotFindWalletInvoiceError,
@@ -138,6 +139,8 @@ export const WalletInvoicesRepository = (): IWalletInvoicesRepository => {
     paid,
     usdAmount,
     externalId,
+    webhookUrl,
+    webhookStatus,
     lnInvoice,
   }: WalletInvoicesPersistNewArgs): Promise<WalletInvoice | RepositoryError> => {
     try {
@@ -153,6 +156,8 @@ export const WalletInvoicesRepository = (): IWalletInvoicesRepository => {
         currency: recipientWalletDescriptor.currency,
         paymentRequest: lnInvoice.paymentRequest,
         externalId,
+        webhookUrl,
+        webhookStatus,
       }).save()
       return ensureWalletInvoiceHasLnInvoice(walletInvoiceFromRaw(walletInvoice))
     } catch (err) {
@@ -190,6 +195,24 @@ export const WalletInvoicesRepository = (): IWalletInvoicesRepository => {
         {
           new: true,
         },
+      )
+      if (!walletInvoice) {
+        return new CouldNotFindWalletInvoiceError()
+      }
+      return walletInvoiceFromRaw(walletInvoice)
+    } catch (err) {
+      return parseRepositoryError(err)
+    }
+  }
+
+  const markWebhookFinalSent = async (
+    paymentHash: PaymentHash,
+  ): Promise<WalletInvoiceWithOptionalLnInvoice | RepositoryError> => {
+    try {
+      const walletInvoice = await WalletInvoice.findOneAndUpdate(
+        { _id: paymentHash },
+        { webhookStatus: WalletInvoiceWebhookStatus.FinalSent },
+        { new: true },
       )
       if (!walletInvoice) {
         return new CouldNotFindWalletInvoiceError()
@@ -251,6 +274,26 @@ export const WalletInvoicesRepository = (): IWalletInvoicesRepository => {
     }
   }
 
+  async function* yieldPendingWebhooks():
+    | AsyncGenerator<WalletInvoiceWithOptionalLnInvoice>
+    | RepositoryError {
+    let pending
+    try {
+      pending = WalletInvoice.find({
+        webhookUrl: { $exists: true },
+        webhookStatus: WalletInvoiceWebhookStatus.Pending,
+      }).cursor({
+        batchSize: 100,
+      })
+    } catch (error) {
+      return new UnknownRepositoryError(error)
+    }
+
+    for await (const walletInvoice of pending) {
+      yield walletInvoiceFromRaw(walletInvoice)
+    }
+  }
+
   const findInvoicesForWallets = async ({
     walletIds,
     paginationArgs,
@@ -276,9 +319,11 @@ export const WalletInvoicesRepository = (): IWalletInvoicesRepository => {
     persistNew,
     markAsPaid,
     markAsProcessingCompleted,
+    markWebhookFinalSent,
     findByPaymentHash,
     findForWalletByPaymentHash,
     yieldPending,
+    yieldPendingWebhooks,
     findInvoicesForWallets,
   }
 }
@@ -307,6 +352,8 @@ const walletInvoiceFromRaw = (
     createdAt: new Date(result.timestamp.getTime()),
     processingCompleted: result.processingCompleted,
     externalId: result.externalId as LedgerExternalId,
+    webhookUrl: result.webhookUrl,
+    webhookStatus: result.webhookStatus as WalletInvoiceWebhookStatus | undefined,
     lnInvoice,
   }
 }

--- a/core/api/src/services/svix/index.ts
+++ b/core/api/src/services/svix/index.ts
@@ -43,6 +43,9 @@ export const CallbackService = (config: SvixConfig): ICallbackService => {
       addEndpoint: nullFn,
       listEndpoints: nullFn,
       deleteEndpoint: nullFn,
+      addInvoiceEndpoint: nullFn,
+      sendInvoiceMessage: nullFn,
+      deleteInvoiceApplication: nullFn,
     }
   }
 
@@ -53,11 +56,14 @@ export const CallbackService = (config: SvixConfig): ICallbackService => {
   const getAccountCallbackId = (accountId: AccountId): AccountCallbackId =>
     `account.${accountId}` as AccountCallbackId
 
-  const createApplication = async (accountCallbackId: AccountCallbackId) => {
+  const getInvoiceCallbackId = (paymentHash: PaymentHash): InvoiceCallbackId =>
+    `invoice.${paymentHash}` as InvoiceCallbackId
+
+  const createApplication = async (callbackId: AccountCallbackId | InvoiceCallbackId) => {
     try {
       const application: ApplicationIn = {
-        name: accountCallbackId,
-        uid: accountCallbackId,
+        name: callbackId,
+        uid: callbackId,
       }
 
       await svix.application.create(application)
@@ -180,9 +186,87 @@ export const CallbackService = (config: SvixConfig): ICallbackService => {
     }
   }
 
+  const addInvoiceEndpoint = async ({
+    paymentHash,
+    url,
+  }: {
+    paymentHash: PaymentHash
+    url: string
+  }) => {
+    const invoiceCallbackId = getInvoiceCallbackId(paymentHash)
+
+    const res = await createApplication(invoiceCallbackId)
+    if (res instanceof Error) return res
+
+    try {
+      const res = await svix.endpoint.create(invoiceCallbackId, { url })
+      return res.id
+    } catch (err) {
+      return handleCommonErrors(err)
+    }
+  }
+
+  const sendInvoiceMessage = async ({
+    paymentHash,
+    eventType,
+    payload,
+  }: {
+    paymentHash: PaymentHash
+    eventType: string
+    payload: Record<string, JSONValue>
+  }): Promise<CallbackError | true> => {
+    const invoiceCallbackId = getInvoiceCallbackId(paymentHash)
+    addAttributesToCurrentSpan({ "callback.application": invoiceCallbackId })
+    try {
+      const result = await createApplication(invoiceCallbackId)
+      if (result instanceof Error) return result
+
+      const safePayload = JSON.parse(
+        JSON.stringify(payload, (_key, value) =>
+          typeof value === "bigint" ? value.toString() : value,
+        ),
+      )
+      const res = await svix.message.create(invoiceCallbackId, {
+        eventType,
+        payload: safePayload,
+      })
+
+      const prefixedPayload = prefixObjectKeys(safePayload, "callback.payload")
+      addAttributesToCurrentSpan({
+        ...prefixedPayload,
+        ["callback.paymentHash"]: paymentHash,
+        ["callback.eventType"]: eventType,
+      })
+      baseLogger.info({ res }, `message sent successfully to ${invoiceCallbackId}`)
+      return true
+    } catch (err) {
+      return handleCommonErrors(err)
+    }
+  }
+
+  const deleteInvoiceApplication = async (paymentHash: PaymentHash) => {
+    const invoiceCallbackId = getInvoiceCallbackId(paymentHash)
+
+    try {
+      await svix.application.delete(invoiceCallbackId)
+      return true
+    } catch (err) {
+      return handleCommonErrors(err)
+    }
+  }
+
   return wrapAsyncFunctionsToRunInSpan({
     namespace: "services.callback",
-    fns: { sendMessage, getPortalUrl, addEndpoint, listEndpoints, deleteEndpoint },
+    fns: {
+      sendMessage,
+      getPortalUrl,
+      addEndpoint,
+      listEndpoints,
+      deleteEndpoint,
+      addInvoiceEndpoint,
+      sendInvoiceMessage,
+      deleteInvoiceApplication,
+    },
   })
 }
 

--- a/core/api/src/services/svix/index.ts
+++ b/core/api/src/services/svix/index.ts
@@ -244,7 +244,11 @@ export const CallbackService = (config: SvixConfig): ICallbackService => {
     }
   }
 
-  const deleteInvoiceApplication = async (paymentHash: PaymentHash) => {
+  const deleteInvoiceApplication = async ({
+    paymentHash,
+  }: {
+    paymentHash: PaymentHash
+  }) => {
     const invoiceCallbackId = getInvoiceCallbackId(paymentHash)
 
     try {

--- a/core/api/test/unit/app/wallets/invoice-webhooks.spec.ts
+++ b/core/api/test/unit/app/wallets/invoice-webhooks.spec.ts
@@ -1,0 +1,124 @@
+import { sendTerminalInvoiceWebhook } from "@/app/wallets/invoice-webhooks"
+import { WalletInvoiceWebhookStatus } from "@/domain/wallet-invoices"
+import { PaymentStatusCheckerByHash } from "@/app/lightning/payment-status-checker"
+import { CallbackService } from "@/services/svix"
+import { WalletInvoicesRepository } from "@/services/mongoose"
+
+jest.mock("@/config", () => ({
+  getCallbackServiceConfig: jest.fn(() => ({ secret: "secret" })),
+}))
+
+jest.mock("@/app/lightning/payment-status-checker", () => ({
+  PaymentStatusCheckerByHash: jest.fn(),
+}))
+
+jest.mock("@/services/svix", () => ({
+  CallbackService: jest.fn(),
+}))
+
+jest.mock("@/services/mongoose", () => ({
+  WalletInvoicesRepository: jest.fn(),
+}))
+
+jest.mock("@/services/logger", () => ({
+  baseLogger: { warn: jest.fn(), error: jest.fn() },
+}))
+
+const paymentHash = "0".repeat(64) as PaymentHash
+const paymentRequest = "lnbc1paymentrequest" as EncodedPaymentRequest
+const paymentPreimage = "1".repeat(64) as SecretPreImage
+
+const walletInvoice = {
+  paymentHash,
+  webhookUrl: "https://example.com/webhook",
+  webhookStatus: WalletInvoiceWebhookStatus.Pending,
+} as WalletInvoiceWithOptionalLnInvoice
+
+const sendInvoiceMessage = jest.fn()
+const deleteInvoiceApplication = jest.fn()
+const markWebhookFinalSent = jest.fn()
+
+beforeEach(() => {
+  jest.resetAllMocks()
+
+  ;(CallbackService as jest.Mock).mockReturnValue({
+    sendInvoiceMessage,
+    deleteInvoiceApplication,
+  })
+  ;(WalletInvoicesRepository as jest.Mock).mockReturnValue({
+    markWebhookFinalSent,
+  })
+  sendInvoiceMessage.mockResolvedValue(true)
+  deleteInvoiceApplication.mockResolvedValue(true)
+  markWebhookFinalSent.mockResolvedValue(walletInvoice)
+})
+
+describe("sendTerminalInvoiceWebhook", () => {
+  it("does not send for pending invoices", async () => {
+    ;(PaymentStatusCheckerByHash as jest.Mock).mockResolvedValue({
+      paymentRequest,
+      isExpired: false,
+      invoiceIsPaid: jest.fn().mockResolvedValue(false),
+    })
+
+    const result = await sendTerminalInvoiceWebhook({ walletInvoice })
+
+    expect(result).toBe(true)
+    expect(sendInvoiceMessage).not.toHaveBeenCalled()
+    expect(markWebhookFinalSent).not.toHaveBeenCalled()
+    expect(deleteInvoiceApplication).not.toHaveBeenCalled()
+  })
+
+  it("sends paid invoice payload without account-scoped fields", async () => {
+    ;(PaymentStatusCheckerByHash as jest.Mock).mockResolvedValue({
+      paymentRequest,
+      isExpired: false,
+      invoiceIsPaid: jest.fn().mockResolvedValue(true),
+      getPreImage: jest.fn().mockResolvedValue(paymentPreimage),
+    })
+
+    const result = await sendTerminalInvoiceWebhook({ walletInvoice })
+
+    expect(result).toBe(true)
+    expect(sendInvoiceMessage).toHaveBeenCalledWith({
+      paymentHash,
+      eventType: "invoice.paid",
+      payload: {
+        paymentHash,
+        paymentRequest,
+        status: "PAID",
+        paymentPreimage,
+      },
+    })
+    expect(sendInvoiceMessage.mock.calls[0][0].payload).not.toHaveProperty("accountId")
+    expect(sendInvoiceMessage.mock.calls[0][0].payload).not.toHaveProperty("walletId")
+    expect(sendInvoiceMessage.mock.calls[0][0].payload).not.toHaveProperty("transaction")
+    expect(markWebhookFinalSent).toHaveBeenCalledWith(paymentHash)
+    expect(deleteInvoiceApplication).toHaveBeenCalledWith(paymentHash)
+  })
+
+  it("sends expired invoice payload without preimage", async () => {
+    ;(PaymentStatusCheckerByHash as jest.Mock).mockResolvedValue({
+      paymentRequest,
+      isExpired: true,
+      invoiceIsPaid: jest.fn().mockResolvedValue(false),
+    })
+
+    const result = await sendTerminalInvoiceWebhook({ walletInvoice })
+
+    expect(result).toBe(true)
+    expect(sendInvoiceMessage).toHaveBeenCalledWith({
+      paymentHash,
+      eventType: "invoice.expired",
+      payload: {
+        paymentHash,
+        paymentRequest,
+        status: "EXPIRED",
+      },
+    })
+    expect(sendInvoiceMessage.mock.calls[0][0].payload).not.toHaveProperty(
+      "paymentPreimage",
+    )
+    expect(markWebhookFinalSent).toHaveBeenCalledWith(paymentHash)
+  })
+})

--- a/core/api/test/unit/app/wallets/send-invoice-webhook.spec.ts
+++ b/core/api/test/unit/app/wallets/send-invoice-webhook.spec.ts
@@ -93,7 +93,7 @@ describe("sendInvoiceWebhook", () => {
     expect(sendInvoiceMessage.mock.calls[0][0].payload).not.toHaveProperty("walletId")
     expect(sendInvoiceMessage.mock.calls[0][0].payload).not.toHaveProperty("transaction")
     expect(markWebhookAsSent).toHaveBeenCalledWith(paymentHash)
-    expect(deleteInvoiceApplication).toHaveBeenCalledWith(paymentHash)
+    expect(deleteInvoiceApplication).toHaveBeenCalledWith({ paymentHash })
   })
 
   it("sends expired invoice payload without preimage", async () => {

--- a/core/api/test/unit/app/wallets/send-invoice-webhook.spec.ts
+++ b/core/api/test/unit/app/wallets/send-invoice-webhook.spec.ts
@@ -1,4 +1,4 @@
-import { sendTerminalInvoiceWebhook } from "@/app/wallets/invoice-webhooks"
+import { sendInvoiceWebhook } from "@/app/wallets/send-invoice-webhook"
 import { WalletInvoiceWebhookStatus } from "@/domain/wallet-invoices"
 import { PaymentStatusCheckerByHash } from "@/app/lightning/payment-status-checker"
 import { CallbackService } from "@/services/svix"
@@ -20,8 +20,8 @@ jest.mock("@/services/mongoose", () => ({
   WalletInvoicesRepository: jest.fn(),
 }))
 
-jest.mock("@/services/logger", () => ({
-  baseLogger: { warn: jest.fn(), error: jest.fn() },
+jest.mock("@/services/tracing", () => ({
+  recordExceptionInCurrentSpan: jest.fn(),
 }))
 
 const paymentHash = "0".repeat(64) as PaymentHash
@@ -36,24 +36,23 @@ const walletInvoice = {
 
 const sendInvoiceMessage = jest.fn()
 const deleteInvoiceApplication = jest.fn()
-const markWebhookFinalSent = jest.fn()
+const markWebhookAsSent = jest.fn()
 
 beforeEach(() => {
   jest.resetAllMocks()
-
   ;(CallbackService as jest.Mock).mockReturnValue({
     sendInvoiceMessage,
     deleteInvoiceApplication,
   })
   ;(WalletInvoicesRepository as jest.Mock).mockReturnValue({
-    markWebhookFinalSent,
+    markWebhookAsSent,
   })
   sendInvoiceMessage.mockResolvedValue(true)
   deleteInvoiceApplication.mockResolvedValue(true)
-  markWebhookFinalSent.mockResolvedValue(walletInvoice)
+  markWebhookAsSent.mockResolvedValue(walletInvoice)
 })
 
-describe("sendTerminalInvoiceWebhook", () => {
+describe("sendInvoiceWebhook", () => {
   it("does not send for pending invoices", async () => {
     ;(PaymentStatusCheckerByHash as jest.Mock).mockResolvedValue({
       paymentRequest,
@@ -61,11 +60,11 @@ describe("sendTerminalInvoiceWebhook", () => {
       invoiceIsPaid: jest.fn().mockResolvedValue(false),
     })
 
-    const result = await sendTerminalInvoiceWebhook({ walletInvoice })
+    const result = await sendInvoiceWebhook({ walletInvoice })
 
     expect(result).toBe(true)
     expect(sendInvoiceMessage).not.toHaveBeenCalled()
-    expect(markWebhookFinalSent).not.toHaveBeenCalled()
+    expect(markWebhookAsSent).not.toHaveBeenCalled()
     expect(deleteInvoiceApplication).not.toHaveBeenCalled()
   })
 
@@ -77,7 +76,7 @@ describe("sendTerminalInvoiceWebhook", () => {
       getPreImage: jest.fn().mockResolvedValue(paymentPreimage),
     })
 
-    const result = await sendTerminalInvoiceWebhook({ walletInvoice })
+    const result = await sendInvoiceWebhook({ walletInvoice })
 
     expect(result).toBe(true)
     expect(sendInvoiceMessage).toHaveBeenCalledWith({
@@ -93,7 +92,7 @@ describe("sendTerminalInvoiceWebhook", () => {
     expect(sendInvoiceMessage.mock.calls[0][0].payload).not.toHaveProperty("accountId")
     expect(sendInvoiceMessage.mock.calls[0][0].payload).not.toHaveProperty("walletId")
     expect(sendInvoiceMessage.mock.calls[0][0].payload).not.toHaveProperty("transaction")
-    expect(markWebhookFinalSent).toHaveBeenCalledWith(paymentHash)
+    expect(markWebhookAsSent).toHaveBeenCalledWith(paymentHash)
     expect(deleteInvoiceApplication).toHaveBeenCalledWith(paymentHash)
   })
 
@@ -104,7 +103,7 @@ describe("sendTerminalInvoiceWebhook", () => {
       invoiceIsPaid: jest.fn().mockResolvedValue(false),
     })
 
-    const result = await sendTerminalInvoiceWebhook({ walletInvoice })
+    const result = await sendInvoiceWebhook({ walletInvoice })
 
     expect(result).toBe(true)
     expect(sendInvoiceMessage).toHaveBeenCalledWith({
@@ -119,6 +118,6 @@ describe("sendTerminalInvoiceWebhook", () => {
     expect(sendInvoiceMessage.mock.calls[0][0].payload).not.toHaveProperty(
       "paymentPreimage",
     )
-    expect(markWebhookFinalSent).toHaveBeenCalledWith(paymentHash)
+    expect(markWebhookAsSent).toHaveBeenCalledWith(paymentHash)
   })
 })

--- a/dev/config/apollo-federation/supergraph.graphql
+++ b/dev/config/apollo-federation/supergraph.graphql
@@ -989,6 +989,7 @@ input LnInvoiceCreateOnBehalfOfRecipientInput
 
   """Wallet ID for a BTC wallet which belongs to any account."""
   recipientWalletId: WalletId!
+  webhookUrl: EndpointUrl
 }
 
 input LnInvoiceFeeProbeInput
@@ -1099,6 +1100,7 @@ input LnNoAmountInvoiceCreateOnBehalfOfRecipientInput
   ID for either a USD or BTC wallet which belongs to the account of any user.
   """
   recipientWalletId: WalletId!
+  webhookUrl: EndpointUrl
 }
 
 input LnNoAmountInvoiceFeeProbeInput
@@ -1210,6 +1212,7 @@ input LnUsdInvoiceBtcDenominatedCreateOnBehalfOfRecipientInput
 
   """Wallet ID for a USD wallet which belongs to the account of any user."""
   recipientWalletId: WalletId!
+  webhookUrl: EndpointUrl
 }
 
 input LnUsdInvoiceCreateInput
@@ -1247,6 +1250,7 @@ input LnUsdInvoiceCreateOnBehalfOfRecipientInput
 
   """Wallet ID for a USD wallet which belongs to the account of any user."""
   recipientWalletId: WalletId!
+  webhookUrl: EndpointUrl
 }
 
 input LnUsdInvoiceFeeProbeInput

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "http-cache-semantics": "4.1.1",
     "elliptic": "^6.6.1",
     "form-data": "^4.0.4",
-    "handlebars": "^4.7.9"
+    "handlebars": "^4.7.9",
+    "shell-quote": "^1.8.4"
   },
   "packageManager": "pnpm@8.7.6"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,6 +12,7 @@ overrides:
   elliptic: ^6.6.1
   form-data: ^4.0.4
   handlebars: ^4.7.9
+  shell-quote: ^1.8.4
 
 importers:
 
@@ -2925,7 +2926,7 @@ packages:
       '@babel/traverse': 7.27.7
       '@babel/types': 7.27.7
       convert-source-map: 1.9.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -2948,7 +2949,7 @@ packages:
       '@babel/traverse': 7.27.7
       '@babel/types': 7.27.7
       convert-source-map: 2.0.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -5627,7 +5628,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -5643,7 +5644,7 @@ packages:
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -5912,7 +5913,7 @@ packages:
       listr2: 4.0.5
       log-symbols: 4.1.0
       micromatch: 4.0.8
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       string-env-interpolation: 1.0.1
       ts-log: 2.2.7
       tslib: 2.8.1
@@ -5974,7 +5975,7 @@ packages:
       listr2: 4.0.5
       log-symbols: 4.1.0
       micromatch: 4.0.8
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       string-env-interpolation: 1.0.1
       ts-log: 2.2.7
       tslib: 2.8.1
@@ -6036,7 +6037,7 @@ packages:
       listr2: 4.0.5
       log-symbols: 4.1.0
       micromatch: 4.0.8
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       string-env-interpolation: 1.0.1
       ts-log: 2.2.7
       tslib: 2.8.1
@@ -6098,7 +6099,7 @@ packages:
       listr2: 4.0.5
       log-symbols: 4.1.0
       micromatch: 4.0.8
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       string-env-interpolation: 1.0.1
       ts-log: 2.2.7
       tslib: 2.8.1
@@ -7326,7 +7327,7 @@ packages:
       '@types/js-yaml': 4.0.9
       '@whatwg-node/fetch': 0.10.8
       chalk: 4.1.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       dotenv: 16.6.1
       graphql: 16.11.0
       graphql-request: 6.1.0(graphql@16.11.0)
@@ -7625,7 +7626,7 @@ packages:
     deprecated: Use @eslint/config-array instead
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -8500,7 +8501,7 @@ packages:
     dependencies:
       '@types/node': 22.16.0
       async-exit-hook: 2.0.1
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       uuid: 11.1.0
     transitivePeerDependencies:
       - supports-color
@@ -14144,7 +14145,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@5.6.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.6.3)
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -14172,7 +14173,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.0)(typescript@5.6.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.6.3)
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.57.0
       graphemer: 1.4.0
       ignore: 5.3.2
@@ -14288,7 +14289,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.8.3)
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.40.0
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -14308,7 +14309,7 @@ packages:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.3)
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.57.0
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -14329,7 +14330,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.57.0
       typescript: 5.2.2
     transitivePeerDependencies:
@@ -14350,7 +14351,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.3.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.57.0
       typescript: 5.3.3
     transitivePeerDependencies:
@@ -14371,7 +14372,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.57.0
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -14392,7 +14393,7 @@ packages:
       '@typescript-eslint/types': 6.21.0
       '@typescript-eslint/typescript-estree': 6.21.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 6.21.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.57.0
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -14413,7 +14414,7 @@ packages:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.2.2)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.57.0
       typescript: 5.2.2
     transitivePeerDependencies:
@@ -14434,7 +14435,7 @@ packages:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.57.0
       typescript: 5.6.3
     transitivePeerDependencies:
@@ -14455,7 +14456,7 @@ packages:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.57.0
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -14473,7 +14474,7 @@ packages:
       '@typescript-eslint/types': 8.35.1
       '@typescript-eslint/typescript-estree': 8.35.1(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.35.1
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 9.30.1
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -14592,7 +14593,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.6.3)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.0)(typescript@5.6.3)
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.57.0
       tsutils: 3.21.0(typescript@5.6.3)
       typescript: 5.6.3
@@ -14612,7 +14613,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.2.2)
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.2.2)
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.57.0
       ts-api-utils: 1.4.3(typescript@5.2.2)
       typescript: 5.2.2
@@ -14632,7 +14633,7 @@ packages:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.8.3)
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.0)(typescript@5.8.3)
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.57.0
       ts-api-utils: 1.4.3(typescript@5.8.3)
       typescript: 5.8.3
@@ -14864,7 +14865,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -14886,7 +14887,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -14908,7 +14909,7 @@ packages:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -18401,7 +18402,6 @@ packages:
     dependencies:
       ms: 2.1.3
       supports-color: 5.5.0
-    dev: true
 
   /debug@4.4.1(supports-color@8.1.1):
     resolution: {integrity: sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==}
@@ -18414,6 +18414,7 @@ packages:
     dependencies:
       ms: 2.1.3
       supports-color: 8.1.1
+    dev: true
 
   /debug@4.4.3(supports-color@8.1.1):
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -19642,7 +19643,7 @@ packages:
         optional: true
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.40.0
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@5.62.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.40.0)
       get-tsconfig: 4.10.1
@@ -19668,7 +19669,7 @@ packages:
         optional: true
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       eslint: 8.57.0
       eslint-plugin-import: 2.32.0(@typescript-eslint/parser@6.21.0)(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.0)
       get-tsconfig: 4.10.1
@@ -20381,7 +20382,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -20432,7 +20433,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -20489,7 +20490,7 @@ packages:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -22380,7 +22381,6 @@ packages:
   /has-flag@3.0.0:
     resolution: {integrity: sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==}
     engines: {node: '>=4'}
-    dev: true
 
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
@@ -22955,7 +22955,7 @@ packages:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -24397,7 +24397,7 @@ packages:
     dependencies:
       '@types/express': 4.17.23
       '@types/jsonwebtoken': 9.0.10
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       jose: 4.15.9
       limiter: 1.1.5
       lru-memoizer: 2.3.0
@@ -24965,7 +24965,7 @@ packages:
       chalk: 4.1.2
       commander: 7.2.0
       commondir: 1.0.1
-      debug: 4.4.1(supports-color@8.1.1)
+      debug: 4.4.1(supports-color@5.5.0)
       dependency-tree: 9.0.0
       detective-amd: 4.2.0
       detective-cjs: 4.1.0
@@ -27668,7 +27668,7 @@ packages:
       prompts: 2.4.2
       react-error-overlay: 6.1.0
       recursive-readdir: 2.2.3
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       strip-ansi: 6.0.1
       text-table: 0.2.0
       typescript: 5.6.3
@@ -28933,8 +28933,8 @@ packages:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
 
-  /shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  /shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
     dev: true
 
@@ -29706,7 +29706,6 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       has-flag: 3.0.0
-    dev: true
 
   /supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}


### PR DESCRIPTION
Adds optional terminal-status webhooks for public invoice creation mutations.\n\n- Uses invoice-scoped Svix applications keyed by payment hash\n- Sends only invoice status fields exposed by the public status query\n- Adds fallback delivery scan and E2E coverage for all modified public mutations