### PR TITLE
feat(api): add allowUsernameSetup config flag

### DIFF
--- a/core/api/galoy.yaml
+++ b/core/api/galoy.yaml
@@ -93,6 +93,7 @@ accounts:
     - BTC
     - USD
   enablePhoneCheck: false
+  allowUsernameSetup: true
   enableIpCheck: false
   enableIpProxyCheck: false
   allowPhoneCountries: []

--- a/core/api/src/app/accounts/set-username.ts
+++ b/core/api/src/app/accounts/set-username.ts
@@ -1,6 +1,6 @@
 import { usernameAvailable } from "./username-available"
 
-import { getAccountsOnboardConfig } from "@/config"
+import { getDefaultAccountsConfig } from "@/config"
 import {
   checkedToAccountId,
   checkedToUsername,
@@ -20,7 +20,7 @@ export const setUsername = async ({
   accountId: string
   username: string
 }): Promise<Account | ApplicationError> => {
-  if (!getAccountsOnboardConfig().allowUsernameSetup) {
+  if (!getDefaultAccountsConfig().allowUsernameSetup) {
     return new UsernameSetupNotAllowedError()
   }
 

--- a/core/api/src/app/accounts/set-username.ts
+++ b/core/api/src/app/accounts/set-username.ts
@@ -1,10 +1,12 @@
 import { usernameAvailable } from "./username-available"
 
+import { getAccountsOnboardConfig } from "@/config"
 import {
   checkedToAccountId,
   checkedToUsername,
   UsernameIsImmutableError,
   UsernameNotAvailableError,
+  UsernameSetupNotAllowedError,
 } from "@/domain/accounts"
 import { InvalidUsername } from "@/domain/errors"
 import { checkedToPhoneNumber } from "@/domain/users"
@@ -18,6 +20,10 @@ export const setUsername = async ({
   accountId: string
   username: string
 }): Promise<Account | ApplicationError> => {
+  if (!getAccountsOnboardConfig().allowUsernameSetup) {
+    return new UsernameSetupNotAllowedError()
+  }
+
   const checkedUsername = checkedToUsername(username)
   if (checkedUsername instanceof Error) return checkedUsername
 

--- a/core/api/src/config/schema.ts
+++ b/core/api/src/config/schema.ts
@@ -742,6 +742,7 @@ export const configSchema = {
           },
         },
         enablePhoneCheck: { type: "boolean" },
+        allowUsernameSetup: { type: "boolean" },
         enableIpCheck: { type: "boolean" },
         enableIpProxyCheck: { type: "boolean" },
         allowPhoneCountries: {
@@ -780,6 +781,7 @@ export const configSchema = {
         "initialStatus",
         "initialWallets",
         "enablePhoneCheck",
+        "allowUsernameSetup",
         "enableIpCheck",
         "enableIpProxyCheck",
         "allowPhoneCountries",
@@ -795,6 +797,7 @@ export const configSchema = {
         initialStatus: "active",
         initialWallets: ["BTC", "USD"],
         enablePhoneCheck: false,
+        allowUsernameSetup: true,
         enableIpCheck: false,
         enableIpProxyCheck: false,
         allowPhoneCountries: [],

--- a/core/api/src/config/schema.types.d.ts
+++ b/core/api/src/config/schema.types.d.ts
@@ -212,6 +212,7 @@ type YamlSchema = {
     initialStatus: string
     initialWallets: WalletCurrency[]
     enablePhoneCheck: boolean
+    allowUsernameSetup: boolean
     enableIpCheck: boolean
     enableIpProxyCheck: boolean
     denyPhoneCountries: string[]

--- a/core/api/src/config/types.d.ts
+++ b/core/api/src/config/types.d.ts
@@ -41,6 +41,7 @@ type AccountsConfig = {
 }
 
 type AccountsOnboardConfig = {
+  allowUsernameSetup: boolean
   phoneMetadataValidationSettings: AccountsOnboardPhoneMetadataConfig
   ipMetadataValidationSettings: AccountsOnboardIpMetadataConfig
 }

--- a/core/api/src/config/types.d.ts
+++ b/core/api/src/config/types.d.ts
@@ -38,10 +38,10 @@ type AccountsConfig = {
   initialWallets: WalletCurrency[]
   initialLevel: AccountLevel
   maxDeletions: number
+  allowUsernameSetup: boolean
 }
 
 type AccountsOnboardConfig = {
-  allowUsernameSetup: boolean
   phoneMetadataValidationSettings: AccountsOnboardPhoneMetadataConfig
   ipMetadataValidationSettings: AccountsOnboardIpMetadataConfig
 }

--- a/core/api/src/config/yaml.ts
+++ b/core/api/src/config/yaml.ts
@@ -297,7 +297,12 @@ export const getDefaultAccountsConfig = (config = yamlConfig): AccountsConfig =>
 })
 
 export const getAccountsOnboardConfig = (config = yamlConfig): AccountsOnboardConfig => {
-  const { enablePhoneCheck, enableIpCheck, enableIpProxyCheck } = config.accounts
+  const {
+    enablePhoneCheck,
+    allowUsernameSetup,
+    enableIpCheck,
+    enableIpProxyCheck,
+  } = config.accounts
 
   const denyPhoneCountries = config.accounts.denyPhoneCountries || []
   const allowPhoneCountries = config.accounts.allowPhoneCountries || []
@@ -307,6 +312,7 @@ export const getAccountsOnboardConfig = (config = yamlConfig): AccountsOnboardCo
   const allowASNs = config.accounts.allowASNs || []
 
   return {
+    allowUsernameSetup,
     phoneMetadataValidationSettings: {
       enabled: enablePhoneCheck,
       denyCountries: denyPhoneCountries.map((c) => c.toUpperCase()),

--- a/core/api/src/config/yaml.ts
+++ b/core/api/src/config/yaml.ts
@@ -294,15 +294,11 @@ export const getDefaultAccountsConfig = (config = yamlConfig): AccountsConfig =>
   initialWallets: config.accounts.initialWallets,
   initialLevel: AccountLevel.One,
   maxDeletions: config.accounts.maxDeletions || 2,
+  allowUsernameSetup: config.accounts.allowUsernameSetup,
 })
 
 export const getAccountsOnboardConfig = (config = yamlConfig): AccountsOnboardConfig => {
-  const {
-    enablePhoneCheck,
-    allowUsernameSetup,
-    enableIpCheck,
-    enableIpProxyCheck,
-  } = config.accounts
+  const { enablePhoneCheck, enableIpCheck, enableIpProxyCheck } = config.accounts
 
   const denyPhoneCountries = config.accounts.denyPhoneCountries || []
   const allowPhoneCountries = config.accounts.allowPhoneCountries || []
@@ -312,7 +308,6 @@ export const getAccountsOnboardConfig = (config = yamlConfig): AccountsOnboardCo
   const allowASNs = config.accounts.allowASNs || []
 
   return {
-    allowUsernameSetup,
     phoneMetadataValidationSettings: {
       enabled: enablePhoneCheck,
       denyCountries: denyPhoneCountries.map((c) => c.toUpperCase()),

--- a/core/api/src/domain/accounts/errors.ts
+++ b/core/api/src/domain/accounts/errors.ts
@@ -4,6 +4,7 @@ export class AccountError extends DomainError {}
 
 export class UsernameNotAvailableError extends AccountError {}
 export class UsernameIsImmutableError extends AccountError {}
+export class UsernameSetupNotAllowedError extends AccountError {}
 
 export class InvalidAccountError extends AccountError {}
 export class InvalidAccountIdError extends AccountError {}

--- a/core/api/src/graphql/error-map.ts
+++ b/core/api/src/graphql/error-map.ts
@@ -451,6 +451,10 @@ export const mapError = (error: ApplicationError): CustomGraphQLError => {
       message = "username is immutable"
       return new UsernameError({ message, logger: baseLogger })
 
+    case "UsernameSetupNotAllowedError":
+      message = "username setup not allowed"
+      return new UsernameError({ message, logger: baseLogger })
+
     case "InvalidWalletId":
       message = "Invalid walletId for account."
       return new ValidationInternalError({ message, logger: baseLogger })

--- a/core/api/test/integration/app/accounts/create-account.spec.ts
+++ b/core/api/test/integration/app/accounts/create-account.spec.ts
@@ -25,6 +25,7 @@ describe("createAccountWithPhoneIdentifier", () => {
           initialStatus: AccountStatus.Active,
           initialWallets,
           maxDeletions: 2,
+          allowUsernameSetup: true,
         },
       })
       if (account instanceof Error) throw account
@@ -61,6 +62,7 @@ describe("createAccountWithPhoneIdentifier", () => {
             initialStatus: AccountStatus.Active,
             initialWallets,
             maxDeletions: 2,
+            allowUsernameSetup: true,
           },
         })
       if (account instanceof Error) throw account
@@ -97,6 +99,7 @@ describe("createAccountWithPhoneIdentifier", () => {
             initialStatus: AccountStatus.Active,
             initialWallets,
             maxDeletions: 2,
+            allowUsernameSetup: true,
           },
         })
       if (account instanceof Error) throw account
@@ -134,6 +137,7 @@ describe("createAccountWithPhoneIdentifier", () => {
             initialStatus: AccountStatus.Active,
             initialWallets,
             maxDeletions: 2,
+            allowUsernameSetup: true,
           },
           phoneMetadata: {
             carrier: {
@@ -172,6 +176,7 @@ describe("createAccountWithPhoneIdentifier", () => {
             initialStatus: AccountStatus.Active,
             initialWallets,
             maxDeletions: 2,
+            allowUsernameSetup: true,
           },
           phoneMetadata: {
             carrier: {
@@ -211,6 +216,7 @@ describe("createAccountWithPhoneIdentifier", () => {
             initialStatus: AccountStatus.Active,
             initialWallets,
             maxDeletions: 2,
+            allowUsernameSetup: true,
           },
           phoneMetadata: {
             carrier: {

--- a/core/api/test/integration/scenarios/hedge-arbitrage.spec.ts
+++ b/core/api/test/integration/scenarios/hedge-arbitrage.spec.ts
@@ -139,6 +139,7 @@ const newAccountAndWallets = async () => {
       initialWallets,
       initialLevel: AccountLevel.One,
       maxDeletions: 2,
+      allowUsernameSetup: true,
     },
   })
   if (account instanceof Error) throw account

--- a/core/api/test/unit/app/accounts/set-username.spec.ts
+++ b/core/api/test/unit/app/accounts/set-username.spec.ts
@@ -1,5 +1,5 @@
 jest.mock("@/config", () => ({
-  getAccountsOnboardConfig: jest.fn(),
+  getDefaultAccountsConfig: jest.fn(),
 }))
 
 jest.mock("@/services/mongoose", () => ({
@@ -8,12 +8,12 @@ jest.mock("@/services/mongoose", () => ({
 
 import { setUsername } from "@/app/accounts/set-username"
 
-import { getAccountsOnboardConfig } from "@/config"
+import { getDefaultAccountsConfig } from "@/config"
 import { UsernameSetupNotAllowedError } from "@/domain/accounts"
 import { AccountsRepository } from "@/services/mongoose"
 
-const mockGetAccountsOnboardConfig = getAccountsOnboardConfig as jest.MockedFunction<
-  typeof getAccountsOnboardConfig
+const mockGetDefaultAccountsConfig = getDefaultAccountsConfig as jest.MockedFunction<
+  typeof getDefaultAccountsConfig
 >
 const mockAccountsRepository = AccountsRepository as jest.MockedFunction<
   typeof AccountsRepository
@@ -22,21 +22,12 @@ const mockAccountsRepository = AccountsRepository as jest.MockedFunction<
 describe("Set username", () => {
   beforeEach(() => {
     jest.resetAllMocks()
-    mockGetAccountsOnboardConfig.mockReturnValue({
+    mockGetDefaultAccountsConfig.mockReturnValue({
+      initialStatus: "active" as AccountStatus,
+      initialWallets: [] as WalletCurrency[],
+      initialLevel: 1 as AccountLevel,
+      maxDeletions: 2,
       allowUsernameSetup: false,
-      phoneMetadataValidationSettings: {
-        enabled: false,
-        denyCountries: [],
-        allowCountries: [],
-      },
-      ipMetadataValidationSettings: {
-        enabled: false,
-        denyCountries: [],
-        allowCountries: [],
-        denyASNs: [],
-        allowASNs: [],
-        checkProxy: false,
-      },
     })
   })
 

--- a/core/api/test/unit/app/accounts/set-username.spec.ts
+++ b/core/api/test/unit/app/accounts/set-username.spec.ts
@@ -1,0 +1,52 @@
+jest.mock("@/config", () => ({
+  getAccountsOnboardConfig: jest.fn(),
+}))
+
+jest.mock("@/services/mongoose", () => ({
+  AccountsRepository: jest.fn(),
+}))
+
+import { setUsername } from "@/app/accounts/set-username"
+
+import { getAccountsOnboardConfig } from "@/config"
+import { UsernameSetupNotAllowedError } from "@/domain/accounts"
+import { AccountsRepository } from "@/services/mongoose"
+
+const mockGetAccountsOnboardConfig = getAccountsOnboardConfig as jest.MockedFunction<
+  typeof getAccountsOnboardConfig
+>
+const mockAccountsRepository = AccountsRepository as jest.MockedFunction<
+  typeof AccountsRepository
+>
+
+describe("Set username", () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+    mockGetAccountsOnboardConfig.mockReturnValue({
+      allowUsernameSetup: false,
+      phoneMetadataValidationSettings: {
+        enabled: false,
+        denyCountries: [],
+        allowCountries: [],
+      },
+      ipMetadataValidationSettings: {
+        enabled: false,
+        denyCountries: [],
+        allowCountries: [],
+        denyASNs: [],
+        allowASNs: [],
+        checkProxy: false,
+      },
+    })
+  })
+
+  it("fails when username setup is disabled", async () => {
+    const result = await setUsername({
+      accountId: crypto.randomUUID(),
+      username: "alice",
+    })
+
+    expect(result).toBeInstanceOf(UsernameSetupNotAllowedError)
+    expect(mockAccountsRepository).not.toHaveBeenCalled()
+  })
+})

--- a/core/api/test/unit/config.spec.ts
+++ b/core/api/test/unit/config.spec.ts
@@ -5,13 +5,9 @@ import * as yaml from "js-yaml"
 
 import mergeWith from "lodash.mergewith"
 
+import { configSchema } from "@/config/schema"
+import { getAccountLimits, yamlConfig, getOnchainNetworkConfig } from "@/config/yaml"
 import { toCents } from "@/domain/fiat"
-import {
-  configSchema,
-  getAccountLimits,
-  yamlConfig,
-  getOnchainNetworkConfig,
-} from "@/config"
 
 const ajv = new Ajv({ discriminator: true, $data: true })
 

--- a/core/api/test/unit/config.spec.ts
+++ b/core/api/test/unit/config.spec.ts
@@ -5,9 +5,13 @@ import * as yaml from "js-yaml"
 
 import mergeWith from "lodash.mergewith"
 
-import { configSchema } from "@/config/schema"
-import { getAccountLimits, yamlConfig, getOnchainNetworkConfig } from "@/config/yaml"
 import { toCents } from "@/domain/fiat"
+import {
+  configSchema,
+  getAccountLimits,
+  yamlConfig,
+  getOnchainNetworkConfig,
+} from "@/config"
 
 const ajv = new Ajv({ discriminator: true, $data: true })
 


### PR DESCRIPTION
Add `accounts.allowUsernameSetup` config flag in `core/api/src/config/schema.ts`
- Default it to `true`
- Gate username setup in `core/api/src/app/accounts/set-username.ts`
- Add `UsernameSetupNotAllowedError` GraphQL mapping
- Regenerate config artifacts/types, including `core/api/galoy.yaml`