### PR TITLE
fix(ci): exclude lnurl data from rsync

### DIFF
--- a/ci/apps/tasks/run-on-nix-host.sh
+++ b/ci/apps/tasks/run-on-nix-host.sh
@@ -41,7 +41,7 @@ tunnel_pid="$!"
 # Retry loop with a 1-second sleep to wait for the rsync command to succeed
 rsync_ready=false
 for i in {1..30}; do
-  rsync -avr --delete --exclude="buck-out/**" --exclude="**/node_modules/**" \
+  rsync -avr --delete --exclude="buck-out/**" --exclude="**/node_modules/**" --exclude="dev/.data/**" \
     -e "ssh -o StrictHostKeyChecking=no -i ${CI_ROOT}/login.ssh -p 2222" \
     "${REPO_PATH}/" \
     "${login_user}@localhost:${REPO_PATH}" && {

--- a/ci/core/tasks/run-on-nix-host.sh
+++ b/ci/core/tasks/run-on-nix-host.sh
@@ -41,7 +41,7 @@ tunnel_pid="$!"
 # Retry loop with a 1-second sleep to wait for the rsync command to succeed
 rsync_ready=false
 for i in {1..30}; do
-  rsync -avr --delete --exclude="buck-out/**" --exclude="**/node_modules/**" \
+  rsync -avr --delete --exclude="buck-out/**" --exclude="**/node_modules/**" --exclude="dev/.data/**" \
     -e "ssh -o StrictHostKeyChecking=no -i ${CI_ROOT}/login.ssh -p 2222" \
     "${REPO_PATH}/" \
     "${login_user}@localhost:${REPO_PATH}" && {

--- a/ci/vendor/tasks/chart-test-integration.sh
+++ b/ci/vendor/tasks/chart-test-integration.sh
@@ -35,7 +35,7 @@ export ADDITIONAL_SSH_OPTS="-o StrictHostKeyChecking=no -i ${CI_ROOT}/login.ssh"
 pushd ${REPO_PATH}
 
 echo "Syncing repo to docker-host... "
-rsync --delete --exclude target -avr -e "ssh -l ${DOCKER_HOST_USER} ${ADDITIONAL_SSH_OPTS}" \
+rsync --delete --exclude target --exclude="dev/.data/**" -avr -e "ssh -l ${DOCKER_HOST_USER} ${ADDITIONAL_SSH_OPTS}" \
   ./ ${DOCKER_HOST_IP}:${REPO_PATH} > /dev/null
 echo "Done!"
 

--- a/ci/vendor/tasks/chart-test-integration.sh
+++ b/ci/vendor/tasks/chart-test-integration.sh
@@ -35,7 +35,7 @@ export ADDITIONAL_SSH_OPTS="-o StrictHostKeyChecking=no -i ${CI_ROOT}/login.ssh"
 pushd ${REPO_PATH}
 
 echo "Syncing repo to docker-host... "
-rsync --delete --exclude target --exclude="dev/.data/**" -avr -e "ssh -l ${DOCKER_HOST_USER} ${ADDITIONAL_SSH_OPTS}" \
+rsync --delete --exclude target -avr -e "ssh -l ${DOCKER_HOST_USER} ${ADDITIONAL_SSH_OPTS}" \
   ./ ${DOCKER_HOST_IP}:${REPO_PATH} > /dev/null
 echo "Done!"
 


### PR DESCRIPTION
## Summary
- exclude `dev/.data/**` from the duplicated nix-host rsync steps in `ci/core/tasks/run-on-nix-host.sh` and `ci/apps/tasks/run-on-nix-host.sh`
- keep the change limited to the CI rsync exclude needed for the root-owned LNURL sqlite data

## Verification
- `bash -n ci/core/tasks/run-on-nix-host.sh ci/apps/tasks/run-on-nix-host.sh ci/vendor/tasks/chart-test-integration.sh`