### PR TITLE
fix(api): set LNURL payment description

### DIFF
--- a/core/api/src/app/accounts/set-username.ts
+++ b/core/api/src/app/accounts/set-username.ts
@@ -72,7 +72,7 @@ export const setUsername = async ({
       btcWalletId: accountWallets.BTC.id,
       usdWalletId: accountWallets.USD.id,
       defaultWallet: lnurlWalletFromCurrency(defaultWalletCurrency),
-      description: checkedUsername,
+      description: `Payment to ${checkedUsername}`,
       identifiers: [checkedUsername],
     })
     if (lnurlAccount instanceof LnurlServerIdentifierConflictError) {

--- a/core/api/src/domain/lnurl-server/errors.ts
+++ b/core/api/src/domain/lnurl-server/errors.ts
@@ -14,9 +14,7 @@ export class LnurlServerForbiddenError extends LnurlServerServiceError {
   level = ErrorLevel.Critical
 }
 
-export class LnurlServerNotFoundError extends LnurlServerServiceError {
-  level = ErrorLevel.Critical
-}
+export class LnurlServerNotFoundError extends LnurlServerServiceError {}
 
 export class LnurlServerUnavailableError extends LnurlServerServiceError {
   level = ErrorLevel.Critical

--- a/core/api/test/unit/app/accounts/set-username.spec.ts
+++ b/core/api/test/unit/app/accounts/set-username.spec.ts
@@ -191,7 +191,7 @@ describe("Set username", () => {
       btcWalletId: accountWallets.BTC.id,
       usdWalletId: accountWallets.USD.id,
       defaultWallet: "btc",
-      description: "alice",
+      description: "Payment to alice",
       identifiers: ["alice"],
     })
     expect(update.mock.invocationCallOrder[0]).toBeGreaterThan(


### PR DESCRIPTION
## Summary
- Set LNURL Blink account descriptions to `Payment to <username>` when creating a username payment address