### PR TITLE
fix: order lnurl-server after oathkeeper in the e2e stack

### DIFF
--- a/dev/docker-compose.deps.yml
+++ b/dev/docker-compose.deps.yml
@@ -330,6 +330,7 @@ services:
       - LNURL_INTERNAL_JWT_AUDIENCE=blink-lnurl-server
       - LNURL_SCHEME=http
       - LNURL_WEBHOOK_DOMAIN=lnurl-server:4088
+    depends_on: [oathkeeper]
   bitcoind:
     image: lnliz/bitcoind:v28.4
     ports:


### PR DESCRIPTION
## What

Add `depends_on: [oathkeeper]` to the `lnurl-server` service in `dev/docker-compose.deps.yml`.

## Why

`blink-lnurl-server` fetches oathkeeper's internal JWKS **once at startup and never retries**. With no startup ordering in the e2e stack, lnurl-server can boot before oathkeeper is serving, then reject every internal JWT with a 401 (`userUpdateUsername` → `LnurlServerUnauthorizedError`). That breaks user/username seeding and cascades into ~16 e2e failures (`CouldNotFindAccountFromUsernameError`).

Ordering `lnurl-server` after `oathkeeper` (which itself depends on kratos/hydra/apollo-router/otel-agent) lets the JWKS endpoint come up before lnurl-server fetches it.
