### PR TITLE
fix: stabilize pay point of sale flow

### DIFF
--- a/apps/pay/components/parse-pos-payment/index.tsx
+++ b/apps/pay/components/parse-pos-payment/index.tsx
@@ -6,12 +6,7 @@ import Image from "next/image"
 import CurrencyInput, { formatValue } from "react-currency-input-field"
 
 import { ACTION_TYPE, ACTIONS } from "@/app/reducer"
-import {
-  safeAmount,
-  getLocaleConfig,
-  extractSearchParams,
-  parseDisplayCurrency,
-} from "@/lib/utils"
+import { safeAmount, getLocaleConfig, parseDisplayCurrency } from "@/lib/utils"
 
 import { useDisplayCurrency } from "@/hooks/use-display-currency"
 
@@ -55,17 +50,31 @@ function ParsePayment({
     inputValue: state.currentAmount,
     defaultSize: 3,
   })
+  const currentQueryMatches = ({
+    amount,
+    memo,
+    display,
+  }: {
+    amount: string
+    memo: string
+    display: string
+  }) => {
+    return (
+      searchParams?.get("amount") === amount &&
+      (searchParams?.get("memo") ?? "") === memo &&
+      searchParams?.get("display") === display
+    )
+  }
   // set all query params on first load, even if they are not passed
   useEffect(() => {
     const initialAmount = safeAmount(state.currentAmount).toString()
     const initialDisplay = display
-    const initialQuery = extractSearchParams(searchParams)
     const newQuery = {
       amount: initialAmount,
       memo: memo ?? "",
       display: initialDisplay,
     }
-    if (initialQuery !== newQuery) {
+    if (!currentQueryMatches(newQuery)) {
       const params = new URLSearchParams({
         amount: initialAmount,
         memo: memo ?? "",
@@ -131,8 +140,7 @@ function ParsePayment({
       display,
     }
 
-    const initialQuery = extractSearchParams(searchParams)
-    if (initialQuery !== newQuery && !skipRouterPush) {
+    if (!currentQueryMatches(newQuery) && !skipRouterPush) {
       const newUrl = new URL(window.location.toString())
       newUrl.pathname = `/${username}`
       newUrl.search = new URLSearchParams(newQuery).toString()

--- a/apps/pay/cypress/e2e/point-of-sale.cy.ts
+++ b/apps/pay/cypress/e2e/point-of-sale.cy.ts
@@ -1,8 +1,67 @@
 import { testData } from "../support/test-config"
 
 const username = "test_user_a"
+const usernamePhone = "+16505554320"
 const cashRegisterUrl = `/${username}?amount=0&display=USD`
+
+const setUsernameMutation = `
+  mutation UserUpdateUsername($input: UserUpdateUsernameInput!) {
+    userUpdateUsername(input: $input) {
+      errors {
+        message
+      }
+      user {
+        id
+      }
+    }
+  }
+`
+
+const accountDefaultWalletQuery = `
+  query AccountDefaultWallet($username: Username!) {
+    accountDefaultWallet(username: $username) {
+      id
+    }
+  }
+`
+
 describe("Point of Sale", () => {
+  before(() => {
+    cy.loginAndGetToken(usernamePhone, testData.CODE)
+      .then((authToken) => {
+        return cy
+          .request({
+            method: "POST",
+            url: "http://localhost:4455/graphql",
+            headers: {
+              Authorization: `Bearer ${authToken}`,
+            },
+            body: {
+              query: setUsernameMutation,
+              variables: {
+                input: { username },
+              },
+            },
+          })
+          .then((response) => {
+            expect(response.body.errors ?? []).to.have.length(0)
+          })
+      })
+      .then(() => {
+        cy.request({
+          method: "POST",
+          url: "http://localhost:4455/graphql",
+          body: {
+            query: accountDefaultWalletQuery,
+            variables: { username },
+          },
+        }).then((response) => {
+          expect(response.body.errors ?? []).to.have.length(0)
+          expect(response.body.data.accountDefaultWallet.id).to.be.a("string")
+        })
+      })
+  })
+
   it("should navigate to user cash register", () => {
     cy.visit("/")
 


### PR DESCRIPTION
Split from #157 to keep the Pay POS route/test stabilization separate from the admin phone-rate-limit reset work.

## Context

The POS flow had a route replacement loop risk because query params were compared by object identity. The Cypress test also depended on fixture account state that was not established inside the test.

## Changes

- Compare current POS query params by value before replacing the route.
- Create and verify the POS Cypress username/default-wallet fixture before exercising the cash register flow.

## Validation

- `buck2 test //apps/pay:lint`
- `buck2 build //apps/pay:build-ci`
- Pay app CI passed on the split PR.
- The failed SDL job was rerun because the log showed an external Rover plugin download timeout, not a code failure.
- BATS passed after rerunning an unrelated onchain-send broadcast retry failure.
