### PR TITLE
feat(admin-panel): add CSV user-id sender for marketing notifications

### DIFF
--- a/apps/admin-panel/app/notifications/page.tsx
+++ b/apps/admin-panel/app/notifications/page.tsx
@@ -7,6 +7,7 @@ import NotificationBuilder, {
 } from "../../components/notification/builder"
 import NotificationTestSender from "../../components/notification/test-sender"
 import NotificationFilteredSender from "../../components/notification/filtered-sender"
+import NotificationCsvSender from "../../components/notification/csv-sender"
 
 export default function NotificationsScreen() {
   const [notification, setNotification] = useState<NotificationContent>({
@@ -29,9 +30,10 @@ export default function NotificationsScreen() {
         setNotification={setNotification}
       />
       {notificationContainsEnglishContent && (
-        <div className="flex space-x-6">
+        <div className="flex flex-wrap gap-6">
           <NotificationTestSender notification={notification} />
           <NotificationFilteredSender notification={notification} />
+          <NotificationCsvSender notification={notification} />
         </div>
       )}
     </div>

--- a/apps/admin-panel/components/notification/__tests__/csv-parse.test.ts
+++ b/apps/admin-panel/components/notification/__tests__/csv-parse.test.ts
@@ -1,0 +1,123 @@
+import { CHUNK_SIZE, USER_ID_REGEX, chunk, parseUserIdsCsv } from "../csv-parse"
+
+// Valid v1-v5 UUIDs (version nibble 1-5, variant nibble 8/9/a/b) — these are the
+// only shapes blink's KratosUserIdRegex accepts.
+const ID_A = "550e8400-e29b-41d4-a716-446655440000"
+const ID_B = "f47ac10b-58cc-4372-a567-0e02b2c3d479"
+const ID_C = "6ba7b810-9dad-11d1-80b4-00c04fd430c8"
+
+describe("USER_ID_REGEX", () => {
+  test("accepts well-formed UUIDs regardless of hex case", () => {
+    expect(USER_ID_REGEX.test(ID_A)).toBe(true)
+    expect(USER_ID_REGEX.test(ID_A.toUpperCase())).toBe(true)
+  })
+
+  test("rejects malformed ids and out-of-range version/variant nibbles", () => {
+    expect(USER_ID_REGEX.test("not-a-uuid")).toBe(false)
+    expect(USER_ID_REGEX.test("user_id")).toBe(false)
+    expect(USER_ID_REGEX.test("550e8400-e29b-41d4-a716")).toBe(false) // too short
+    expect(USER_ID_REGEX.test("g50e8400-e29b-41d4-a716-446655440000")).toBe(false) // non-hex
+    expect(USER_ID_REGEX.test("00000000-0000-0000-0000-000000000000")).toBe(false) // v0
+    expect(USER_ID_REGEX.test("550e8400-e29b-41d4-c716-446655440000")).toBe(false) // variant c
+  })
+})
+
+describe("parseUserIdsCsv", () => {
+  test("parses a one-per-line list", () => {
+    const { userIds, summary } = parseUserIdsCsv(`${ID_A}\n${ID_B}\n${ID_C}`, "ids.txt")
+    expect(userIds).toEqual([ID_A, ID_B, ID_C])
+    expect(summary).toEqual({
+      fileName: "ids.txt",
+      totalRows: 3,
+      validUnique: 3,
+      duplicates: 0,
+      invalid: 0,
+    })
+  })
+
+  test("parses comma- and semicolon-separated values", () => {
+    expect(parseUserIdsCsv(`${ID_A},${ID_B}`, "f").userIds).toEqual([ID_A, ID_B])
+    expect(parseUserIdsCsv(`${ID_A};${ID_B}`, "f").userIds).toEqual([ID_A, ID_B])
+  })
+
+  test("tolerates mixed whitespace, blank lines and trailing separators", () => {
+    const { userIds } = parseUserIdsCsv(`\n  ${ID_A}\t\r\n\n${ID_B} ,\n`, "f")
+    expect(userIds).toEqual([ID_A, ID_B])
+  })
+
+  test("strips single and double wrapping quotes", () => {
+    const { userIds } = parseUserIdsCsv(`"${ID_A}"\n'${ID_B}'`, "f")
+    expect(userIds).toEqual([ID_A, ID_B])
+  })
+
+  test("dedupes and counts duplicates while preserving first-seen order", () => {
+    const { userIds, summary } = parseUserIdsCsv(`${ID_B}\n${ID_A}\n${ID_B}`, "f")
+    expect(userIds).toEqual([ID_B, ID_A])
+    expect(summary.validUnique).toBe(2)
+    expect(summary.duplicates).toBe(1)
+    expect(summary.totalRows).toBe(3)
+  })
+
+  test("counts invalid rows (e.g. a header line or non-uuid cell) as skipped", () => {
+    const { userIds, summary } = parseUserIdsCsv(`user_id\n${ID_A}\ngarbage`, "f")
+    expect(userIds).toEqual([ID_A])
+    expect(summary.invalid).toBe(2)
+    expect(summary.validUnique).toBe(1)
+  })
+
+  test("splits a multi-column CSV row and drops the non-id column", () => {
+    const { userIds, summary } = parseUserIdsCsv(
+      `${ID_A},alice@example.com\n${ID_B},bob@example.com`,
+      "f",
+    )
+    expect(userIds).toEqual([ID_A, ID_B])
+    expect(summary.invalid).toBe(2) // the two email cells
+  })
+
+  test("strips a leading UTF-8 BOM instead of invalidating the first id", () => {
+    const { userIds, summary } = parseUserIdsCsv(`\ufeff${ID_A}\n${ID_B}`, "f")
+    expect(userIds).toEqual([ID_A, ID_B])
+    expect(summary.invalid).toBe(0)
+  })
+
+  test("returns an empty result for empty or whitespace-only input", () => {
+    const { userIds, summary } = parseUserIdsCsv("\n  \t\n", "empty.csv")
+    expect(userIds).toEqual([])
+    expect(summary).toEqual({
+      fileName: "empty.csv",
+      totalRows: 0,
+      validUnique: 0,
+      duplicates: 0,
+      invalid: 0,
+    })
+  })
+})
+
+describe("chunk", () => {
+  test("splits into batches of the given size with a partial final batch", () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]])
+  })
+
+  test("splits evenly when the length is a multiple of the size", () => {
+    expect(chunk([1, 2, 3, 4], 2)).toEqual([
+      [1, 2],
+      [3, 4],
+    ])
+  })
+
+  test("returns a single batch when the size exceeds the length", () => {
+    expect(chunk([1, 2, 3], 10)).toEqual([[1, 2, 3]])
+  })
+
+  test("returns no batches for an empty array", () => {
+    expect(chunk([], CHUNK_SIZE)).toEqual([])
+  })
+
+  test("respects the CHUNK_SIZE boundary the sender relies on", () => {
+    const ids = Array.from({ length: CHUNK_SIZE + 1 }, (_, i) => i)
+    const batches = chunk(ids, CHUNK_SIZE)
+    expect(batches).toHaveLength(2)
+    expect(batches[0]).toHaveLength(CHUNK_SIZE)
+    expect(batches[1]).toHaveLength(1)
+  })
+})

--- a/apps/admin-panel/components/notification/csv-parse.ts
+++ b/apps/admin-panel/components/notification/csv-parse.ts
@@ -1,0 +1,72 @@
+// blink validates every userId against KratosUserIdRegex (= UuidRegex,
+// core/api/src/domain/shared/validation.ts). We mirror it here and drop bad rows
+// client-side: the mutation rejects the ENTIRE batch on the first invalid id, so
+// a stray header line or blank cell would otherwise fail a whole 1,000-user batch.
+export const USER_ID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+// The admin GraphQL API parses request bodies with express.json()'s default
+// 100 kB limit. A userId is ~40 bytes inside the JSON array, so we keep each
+// mutation call to CHUNK_SIZE ids (well under the limit, leaving room for the
+// notification content payload) and loop over the batches.
+export const CHUNK_SIZE = 1000
+
+export const chunk = <T>(arr: T[], size: number): T[][] => {
+  const out: T[][] = []
+  for (let i = 0; i < arr.length; i += size) {
+    out.push(arr.slice(i, i + size))
+  }
+  return out
+}
+
+export type ParseSummary = {
+  fileName: string
+  totalRows: number
+  validUnique: number
+  duplicates: number
+  invalid: number
+}
+
+export type ParseResult = {
+  userIds: string[]
+  summary: ParseSummary
+}
+
+// Split on commas, semicolons and any whitespace so a one-per-line list, a single
+// CSV column, or a comma-separated row all work. Strip wrapping quotes, then keep
+// only valid, unique user IDs — tracking how many rows were duplicates or invalid.
+export const parseUserIdsCsv = (text: string, fileName: string): ParseResult => {
+  const tokens = text
+    .split(/[\s,;]+/)
+    .map((token) => token.trim().replace(/^["']|["']$/g, ""))
+    .filter(Boolean)
+
+  const seen = new Set<string>()
+  const valid: string[] = []
+  let duplicates = 0
+  let invalid = 0
+
+  for (const token of tokens) {
+    if (!USER_ID_REGEX.test(token)) {
+      invalid++
+      continue
+    }
+    if (seen.has(token)) {
+      duplicates++
+      continue
+    }
+    seen.add(token)
+    valid.push(token)
+  }
+
+  return {
+    userIds: valid,
+    summary: {
+      fileName,
+      totalRows: tokens.length,
+      validUnique: valid.length,
+      duplicates,
+      invalid,
+    },
+  }
+}

--- a/apps/admin-panel/components/notification/csv-sender.tsx
+++ b/apps/admin-panel/components/notification/csv-sender.tsx
@@ -7,35 +7,7 @@ import {
   filteredUserCount as gqlFilteredUserCount,
   triggerMarketingNotification,
 } from "./notification-actions"
-
-// blink-core validates every userId against KratosUserIdRegex (= UuidRegex,
-// core/api/src/domain/shared/validation.ts). We mirror it here and drop bad rows
-// client-side: the mutation rejects the ENTIRE batch on the first invalid id, so
-// a stray header line or blank cell would otherwise fail a whole 1,000-user batch.
-const USER_ID_REGEX =
-  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-
-// The admin GraphQL API parses request bodies with express.json()'s default
-// 100 kB limit. A userId is ~40 bytes inside the JSON array, so we keep each
-// mutation call to CHUNK_SIZE ids (well under the limit, leaving room for the
-// notification content payload) and loop over the batches.
-const CHUNK_SIZE = 1000
-
-const chunk = <T,>(arr: T[], size: number): T[][] => {
-  const out: T[][] = []
-  for (let i = 0; i < arr.length; i += size) {
-    out.push(arr.slice(i, i + size))
-  }
-  return out
-}
-
-type ParseSummary = {
-  fileName: string
-  totalRows: number
-  validUnique: number
-  duplicates: number
-  invalid: number
-}
+import { CHUNK_SIZE, ParseSummary, chunk, parseUserIdsCsv } from "./csv-parse"
 
 type BatchFailure = {
   userIds: string[]
@@ -53,6 +25,7 @@ const NotificationCsvSender = ({ notification }: NotificationCsvSenderArgs) => {
 
   const [filteredCount, setFilteredCount] = useState<number | null>(null)
   const [loadingCount, setLoadingCount] = useState(false)
+  const [countError, setCountError] = useState<string | undefined>(undefined)
 
   const [sending, setSending] = useState(false)
   const [progress, setProgress] = useState<{ sent: number; total: number } | null>(null)
@@ -72,6 +45,7 @@ const NotificationCsvSender = ({ notification }: NotificationCsvSenderArgs) => {
     setSummary(null)
     setUserIds([])
     setFilteredCount(null)
+    setCountError(undefined)
     resetSendState()
 
     const file = e.target.files?.[0]
@@ -79,39 +53,9 @@ const NotificationCsvSender = ({ notification }: NotificationCsvSenderArgs) => {
 
     try {
       const text = await file.text()
-      // Split on commas, semicolons and any whitespace so a one-per-line list, a
-      // single CSV column, or a comma-separated row all work. Strip wrapping quotes.
-      const tokens = text
-        .split(/[\s,;]+/)
-        .map((token) => token.trim().replace(/^["']|["']$/g, ""))
-        .filter(Boolean)
-
-      const seen = new Set<string>()
-      const valid: string[] = []
-      let duplicates = 0
-      let invalid = 0
-
-      for (const token of tokens) {
-        if (!USER_ID_REGEX.test(token)) {
-          invalid++
-          continue
-        }
-        if (seen.has(token)) {
-          duplicates++
-          continue
-        }
-        seen.add(token)
-        valid.push(token)
-      }
-
+      const { userIds: valid, summary: parsed } = parseUserIdsCsv(text, file.name)
       setUserIds(valid)
-      setSummary({
-        fileName: file.name,
-        totalRows: tokens.length,
-        validUnique: valid.length,
-        duplicates,
-        invalid,
-      })
+      setSummary(parsed)
     } catch (err) {
       setParseError(err instanceof Error ? err.message : "Could not read file")
     }
@@ -121,14 +65,15 @@ const NotificationCsvSender = ({ notification }: NotificationCsvSenderArgs) => {
     if (userIds.length === 0) return
     setLoadingCount(true)
     setFilteredCount(null)
+    setCountError(undefined)
     try {
-      // filteredUserCount rides the same 100 kB body limit, so count per chunk and
-      // sum — the ids are distinct, so per-chunk counts add up without overlap.
       let total = 0
       for (const batch of chunk(userIds, CHUNK_SIZE)) {
         total += await gqlFilteredUserCount({ userIdsFilter: batch })
       }
       setFilteredCount(total)
+    } catch (err) {
+      setCountError(err instanceof Error ? err.message : "Could not fetch user count")
     } finally {
       setLoadingCount(false)
     }
@@ -139,35 +84,41 @@ const NotificationCsvSender = ({ notification }: NotificationCsvSenderArgs) => {
     setDone(false)
     const newFailures: BatchFailure[] = []
 
-    for (let i = 0; i < batches.length; i++) {
-      const batch = batches[i]
-      const res = await triggerMarketingNotification({
-        userIdsFilter: batch,
-        openDeepLink: notification.openDeepLink,
-        openExternalUrl: notification.openExternalUrl,
-        icon: notification.icon,
-        shouldSendPush: notification.shouldSendPush,
-        shouldAddToHistory: notification.shouldAddToHistory,
-        shouldAddToBulletin: notification.shouldAddToBulletin,
-        localizedNotificationContents: notification.localizedNotificationContents,
-      })
-      if (res.success) {
-        // Accumulate with a functional update so a fresh send (after
-        // resetSendState sets it to 0) and a retry (which adds on top of the
-        // already-notified total) both stay correct regardless of render timing.
-        setNotifiedCount((prev) => prev + batch.length)
-      } else {
-        newFailures.push({
-          userIds: batch,
-          message: res.message ?? "Unknown error",
-        })
+    try {
+      for (let i = 0; i < batches.length; i++) {
+        const batch = batches[i]
+        try {
+          const res = await triggerMarketingNotification({
+            userIdsFilter: batch,
+            openDeepLink: notification.openDeepLink,
+            openExternalUrl: notification.openExternalUrl,
+            icon: notification.icon,
+            shouldSendPush: notification.shouldSendPush,
+            shouldAddToHistory: notification.shouldAddToHistory,
+            shouldAddToBulletin: notification.shouldAddToBulletin,
+            localizedNotificationContents: notification.localizedNotificationContents,
+          })
+          if (res.success) {
+            setNotifiedCount((prev) => prev + batch.length)
+          } else {
+            newFailures.push({
+              userIds: batch,
+              message: res.message ?? "Unknown error",
+            })
+          }
+        } catch (err) {
+          newFailures.push({
+            userIds: batch,
+            message: err instanceof Error ? err.message : "Request failed",
+          })
+        }
+        setProgress({ sent: i + 1, total: batches.length })
       }
-      setProgress({ sent: i + 1, total: batches.length })
+    } finally {
+      setFailures(newFailures)
+      setSending(false)
+      setDone(true)
     }
-
-    setFailures(newFailures)
-    setSending(false)
-    setDone(true)
   }
 
   const onSend = async () => {
@@ -232,6 +183,7 @@ const NotificationCsvSender = ({ notification }: NotificationCsvSenderArgs) => {
             Get user notification count
           </button>
           {loadingCount && <p>Loading...</p>}
+          {countError && <p className="text-red-500">{countError}</p>}
           {filteredCount !== null && (
             <p>
               Users that exist for these IDs: {filteredCount}
@@ -255,14 +207,14 @@ const NotificationCsvSender = ({ notification }: NotificationCsvSenderArgs) => {
 
       {progress && (
         <p>
-          Batches sent: {progress.sent}/{progress.total} — notified {notifiedCount}{" "}
-          user(s)
+          Batches sent: {progress.sent}/{progress.total} — {notifiedCount} ID(s) submitted
         </p>
       )}
 
       {done && failures.length === 0 && (
         <p className="text-green-500">
-          All batches sent — {notifiedCount} user(s) notified.
+          All batches sent — {notifiedCount} ID(s) submitted. Only IDs matching an
+          existing user are notified.
         </p>
       )}
 

--- a/apps/admin-panel/components/notification/csv-sender.tsx
+++ b/apps/admin-panel/components/notification/csv-sender.tsx
@@ -1,0 +1,288 @@
+"use client"
+
+import { useState } from "react"
+
+import { NotificationContent } from "./builder"
+import {
+  filteredUserCount as gqlFilteredUserCount,
+  triggerMarketingNotification,
+} from "./notification-actions"
+
+// blink-core validates every userId against KratosUserIdRegex (= UuidRegex,
+// core/api/src/domain/shared/validation.ts). We mirror it here and drop bad rows
+// client-side: the mutation rejects the ENTIRE batch on the first invalid id, so
+// a stray header line or blank cell would otherwise fail a whole 1,000-user batch.
+const USER_ID_REGEX =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+
+// The admin GraphQL API parses request bodies with express.json()'s default
+// 100 kB limit. A userId is ~40 bytes inside the JSON array, so we keep each
+// mutation call to CHUNK_SIZE ids (well under the limit, leaving room for the
+// notification content payload) and loop over the batches.
+const CHUNK_SIZE = 1000
+
+const chunk = <T,>(arr: T[], size: number): T[][] => {
+  const out: T[][] = []
+  for (let i = 0; i < arr.length; i += size) {
+    out.push(arr.slice(i, i + size))
+  }
+  return out
+}
+
+type ParseSummary = {
+  fileName: string
+  totalRows: number
+  validUnique: number
+  duplicates: number
+  invalid: number
+}
+
+type BatchFailure = {
+  userIds: string[]
+  message: string
+}
+
+type NotificationCsvSenderArgs = {
+  notification: NotificationContent
+}
+
+const NotificationCsvSender = ({ notification }: NotificationCsvSenderArgs) => {
+  const [userIds, setUserIds] = useState<string[]>([])
+  const [summary, setSummary] = useState<ParseSummary | null>(null)
+  const [parseError, setParseError] = useState<string | undefined>(undefined)
+
+  const [filteredCount, setFilteredCount] = useState<number | null>(null)
+  const [loadingCount, setLoadingCount] = useState(false)
+
+  const [sending, setSending] = useState(false)
+  const [progress, setProgress] = useState<{ sent: number; total: number } | null>(null)
+  const [notifiedCount, setNotifiedCount] = useState(0)
+  const [failures, setFailures] = useState<BatchFailure[]>([])
+  const [done, setDone] = useState(false)
+
+  const resetSendState = () => {
+    setProgress(null)
+    setNotifiedCount(0)
+    setFailures([])
+    setDone(false)
+  }
+
+  const onFile = async (e: React.ChangeEvent<HTMLInputElement>) => {
+    setParseError(undefined)
+    setSummary(null)
+    setUserIds([])
+    setFilteredCount(null)
+    resetSendState()
+
+    const file = e.target.files?.[0]
+    if (!file) return
+
+    try {
+      const text = await file.text()
+      // Split on commas, semicolons and any whitespace so a one-per-line list, a
+      // single CSV column, or a comma-separated row all work. Strip wrapping quotes.
+      const tokens = text
+        .split(/[\s,;]+/)
+        .map((token) => token.trim().replace(/^["']|["']$/g, ""))
+        .filter(Boolean)
+
+      const seen = new Set<string>()
+      const valid: string[] = []
+      let duplicates = 0
+      let invalid = 0
+
+      for (const token of tokens) {
+        if (!USER_ID_REGEX.test(token)) {
+          invalid++
+          continue
+        }
+        if (seen.has(token)) {
+          duplicates++
+          continue
+        }
+        seen.add(token)
+        valid.push(token)
+      }
+
+      setUserIds(valid)
+      setSummary({
+        fileName: file.name,
+        totalRows: tokens.length,
+        validUnique: valid.length,
+        duplicates,
+        invalid,
+      })
+    } catch (err) {
+      setParseError(err instanceof Error ? err.message : "Could not read file")
+    }
+  }
+
+  const getCount = async () => {
+    if (userIds.length === 0) return
+    setLoadingCount(true)
+    setFilteredCount(null)
+    try {
+      // filteredUserCount rides the same 100 kB body limit, so count per chunk and
+      // sum — the ids are distinct, so per-chunk counts add up without overlap.
+      let total = 0
+      for (const batch of chunk(userIds, CHUNK_SIZE)) {
+        total += await gqlFilteredUserCount({ userIdsFilter: batch })
+      }
+      setFilteredCount(total)
+    } finally {
+      setLoadingCount(false)
+    }
+  }
+
+  const sendBatches = async (batches: string[][]) => {
+    setSending(true)
+    setDone(false)
+    const newFailures: BatchFailure[] = []
+
+    for (let i = 0; i < batches.length; i++) {
+      const batch = batches[i]
+      const res = await triggerMarketingNotification({
+        userIdsFilter: batch,
+        openDeepLink: notification.openDeepLink,
+        openExternalUrl: notification.openExternalUrl,
+        icon: notification.icon,
+        shouldSendPush: notification.shouldSendPush,
+        shouldAddToHistory: notification.shouldAddToHistory,
+        shouldAddToBulletin: notification.shouldAddToBulletin,
+        localizedNotificationContents: notification.localizedNotificationContents,
+      })
+      if (res.success) {
+        // Accumulate with a functional update so a fresh send (after
+        // resetSendState sets it to 0) and a retry (which adds on top of the
+        // already-notified total) both stay correct regardless of render timing.
+        setNotifiedCount((prev) => prev + batch.length)
+      } else {
+        newFailures.push({
+          userIds: batch,
+          message: res.message ?? "Unknown error",
+        })
+      }
+      setProgress({ sent: i + 1, total: batches.length })
+    }
+
+    setFailures(newFailures)
+    setSending(false)
+    setDone(true)
+  }
+
+  const onSend = async () => {
+    if (userIds.length === 0) return
+    const batchCount = Math.ceil(userIds.length / CHUNK_SIZE)
+    const confirmed = window.confirm(
+      `Send this notification to ${userIds.length} user(s) across ${batchCount} batch(es)?`,
+    )
+    if (!confirmed) return
+    resetSendState()
+    await sendBatches(chunk(userIds, CHUNK_SIZE))
+  }
+
+  const onRetryFailed = async () => {
+    if (failures.length === 0) return
+    const retryBatches = failures.map((failure) => failure.userIds)
+    setFailures([])
+    await sendBatches(retryBatches)
+  }
+
+  const notFoundCount = filteredCount !== null ? userIds.length - filteredCount : 0
+  const failedUserCount = failures.reduce(
+    (total, failure) => total + failure.userIds.length,
+    0,
+  )
+
+  return (
+    <div className="rounded bg-white mt-6 p-6 space-y-4 flex-1 max-w-lg">
+      <h2>Send From CSV (User IDs)</h2>
+      <p className="text-sm text-gray-500">
+        Upload a CSV/TXT of user IDs (one per line or comma-separated). Rows are deduped
+        and validated, then sent in batches of {CHUNK_SIZE} to stay under the admin API
+        request-size limit.
+      </p>
+      <input
+        type="file"
+        accept=".csv,.txt,text/csv,text/plain"
+        onChange={onFile}
+        disabled={sending}
+      />
+      {parseError && <p className="text-red-500">{parseError}</p>}
+
+      {summary && (
+        <div className="border border-2 p-4 rounded text-sm space-y-1">
+          <p>File: {summary.fileName}</p>
+          <p>Rows parsed: {summary.totalRows}</p>
+          <p className="font-semibold">Valid unique user IDs: {summary.validUnique}</p>
+          {summary.duplicates > 0 && <p>Duplicates removed: {summary.duplicates}</p>}
+          {summary.invalid > 0 && (
+            <p className="text-orange-600">Invalid rows skipped: {summary.invalid}</p>
+          )}
+        </div>
+      )}
+
+      {userIds.length > 0 && (
+        <div className="space-y-2">
+          <button
+            onClick={getCount}
+            disabled={loadingCount || sending}
+            className="bg-blue-500 text-white px-4 py-2 rounded disabled:opacity-50"
+          >
+            Get user notification count
+          </button>
+          {loadingCount && <p>Loading...</p>}
+          {filteredCount !== null && (
+            <p>
+              Users that exist for these IDs: {filteredCount}
+              {notFoundCount > 0 && (
+                <span className="text-orange-600"> ({notFoundCount} not found)</span>
+              )}
+            </p>
+          )}
+        </div>
+      )}
+
+      {userIds.length > 0 && (
+        <button
+          onClick={onSend}
+          disabled={sending}
+          className="bg-blue-500 text-white px-4 py-2 rounded block w-full disabled:opacity-50"
+        >
+          Send to {userIds.length} user(s)
+        </button>
+      )}
+
+      {progress && (
+        <p>
+          Batches sent: {progress.sent}/{progress.total} — notified {notifiedCount}{" "}
+          user(s)
+        </p>
+      )}
+
+      {done && failures.length === 0 && (
+        <p className="text-green-500">
+          All batches sent — {notifiedCount} user(s) notified.
+        </p>
+      )}
+
+      {done && failures.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-red-500">
+            {failures.length} batch(es) failed ({failedUserCount} user(s) not notified).
+            First error: {failures[0].message}
+          </p>
+          <button
+            onClick={onRetryFailed}
+            disabled={sending}
+            className="bg-blue-500 text-white px-4 py-2 rounded disabled:opacity-50"
+          >
+            Retry failed batches
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default NotificationCsvSender


### PR DESCRIPTION
## Summary
- Adds a **Send From CSV (User IDs)** panel to the admin notifications screen for sending a marketing push to an uploaded list of user IDs.
- Validates + dedupes IDs client-side and sends them in batches of 1,000 to stay under the admin API's `express.json()` request-size limit.
- Hardens the batch send against transport errors and covers the parsing logic with unit tests.
