### PR TITLE
fix(ci): clean LNURL state before BATS

### DIFF
--- a/bats/ci_run.sh
+++ b/bats/ci_run.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
 
-# CI Nix hosts are reused and dev/.data is excluded from rsync, so lnurl.db
-# can persist between jobs and make username availability depend on prior runs.
 echo "Cleaning persisted LNURL server SQLite state..."
 rm -f dev/.data/lnurl.db dev/.data/lnurl.db-shm dev/.data/lnurl.db-wal
 

--- a/bats/ci_run.sh
+++ b/bats/ci_run.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+# CI Nix hosts are reused and dev/.data is excluded from rsync, so lnurl.db
+# can persist between jobs and make username availability depend on prior runs.
+echo "Cleaning persisted LNURL server SQLite state..."
+rm -f dev/.data/lnurl.db dev/.data/lnurl.db-shm dev/.data/lnurl.db-wal
+
 echo "Running node_modules build..."
 buck2 build //:node_modules --verbose 4
 


### PR DESCRIPTION
## Summary

- Clean persisted LNURL server SQLite files before running BATS CI
- Document why reusable Nix hosts can leak `dev/.data/lnurl.db` across jobs
- Keep cleanup scoped to `lnurl.db`, `lnurl.db-shm`, and `lnurl.db-wal`

## Why

The `ci/` pipeline runs on reusable Nix hosts and excludes `dev/.data/**` from rsync. Blink Core's local `lnurl-server` stores SQLite state in `dev/.data/lnurl.db`, so stale LNURL identifiers can persist between jobs.

This can make username availability depend on which Nix host picks up the job. In particular, stale `xyz_zap_receiver` LNURL state can cause BATS setup to skip recreating the blink-core user, leading to random LNURL payment failures.

GitHub Actions fails less often because it runs on fresh hosted runners.