### PR TITLE
fix(ci): remove root-owned LNURL state

### DIFF
--- a/bats/ci_run.sh
+++ b/bats/ci_run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "Cleaning persisted LNURL server SQLite state..."
-rm -f dev/.data/lnurl.db dev/.data/lnurl.db-shm dev/.data/lnurl.db-wal
+sudo rm -f dev/.data/lnurl.db dev/.data/lnurl.db-shm dev/.data/lnurl.db-wal
 
 echo "Running node_modules build..."
 buck2 build //:node_modules --verbose 4


### PR DESCRIPTION
## Summary

- Use `sudo rm -f` when cleaning persisted LNURL server SQLite files before BATS CI
- Handles LNURL DB files created by Docker as root on reusable CI Nix hosts

## Why

The previous cleanup can fail with `Permission denied` when `dev/.data/lnurl.db` is owned by root from the `lnurl-server` container. Using `sudo` keeps the cleanup effective for reused CI hosts.